### PR TITLE
Ensure the local authority names appear in alphabetical order in the list of filters

### DIFF
--- a/HerPortal/Models/HomepageViewModel.cs
+++ b/HerPortal/Models/HomepageViewModel.cs
@@ -58,6 +58,7 @@ public class HomepageViewModel
                     }
                 )
             )
+            .OrderBy(kvp => kvp.Key)
         );
         CsvFiles = csvFiles.Select(cf => new CsvFile(cf));
     }


### PR DESCRIPTION
![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta/assets/4410524/bec39c2b-14a3-4ba6-bb90-fa5eb282d8eb)
Previously they appeared in order of their internal DB ID, which doesn't correspond to alphabetical order