### PR TITLE
BH-551: Connect the portal to S3

### DIFF
--- a/HerPortal.BusinessLogic/ExternalServices/S3FileReader/IS3FileReader.cs
+++ b/HerPortal.BusinessLogic/ExternalServices/S3FileReader/IS3FileReader.cs
@@ -1,0 +1,9 @@
+﻿using Amazon.S3.Model;
+
+namespace HerPortal.Data.ExternalServices.S3FileReader;
+
+public interface IS3FileReader
+{
+    public Task<Stream> ReadFileAsync(string custodianCode, int year, int month);
+    public Task<IEnumerable<S3Object>> GetS3ObjectsByCustodianCodeAsync(string custodianCode);
+}

--- a/HerPortal.BusinessLogic/ExternalServices/S3FileReader/S3FileReader.cs
+++ b/HerPortal.BusinessLogic/ExternalServices/S3FileReader/S3FileReader.cs
@@ -1,0 +1,103 @@
+﻿using Amazon;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Transfer;
+using HerPublicWebsite.BusinessLogic.ExternalServices.S3FileWriter;
+using HerPublicWebsite.BusinessLogic.Services.S3ReferralFileKeyGenerator;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HerPortal.Data.ExternalServices.S3FileReader;
+
+public class S3FileReader : IS3FileReader
+{
+    private readonly S3FileReaderConfiguration config;
+    private readonly S3ReferralFileKeyService keyService;
+
+    private readonly ILogger logger;
+
+    public S3FileReader
+    (
+        IOptions<S3FileReaderConfiguration> options,
+        S3ReferralFileKeyService keyService,
+        ILogger<S3FileReader> logger
+    ) {
+        this.config = options.Value;
+        this.keyService = keyService;
+
+        this.logger = logger;
+    }
+    
+    public async Task<Stream> ReadFileAsync(string custodianCode, int year, int month)
+    {
+        var key = keyService.GetS3KeyFromData(custodianCode, year, month);
+
+        try
+        {
+            var s3Client = new AmazonS3Client(RegionEndpoint.GetBySystemName(config.Region));
+            var fileTransferUtility = new TransferUtility(s3Client);
+
+            return await fileTransferUtility.OpenStreamAsync(config.BucketName, key);
+        }
+        catch (AmazonS3Exception ex)
+        { 
+            logger.LogError
+            (
+                "AWS S3 error when reading CSV file from bucket: \"{BucketName}\", key: \"{Key}\". Message: \"{Message}\"",
+                config.BucketName,
+                key,
+                ex.Message
+            );
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError
+            (
+                "Error when reading CSV file from bucket: \"{BucketName}\", key: \"{Key}\". Message: \"{Message}\"",
+                config.BucketName,
+                key,
+                ex.Message
+            );
+            throw;
+        }
+    }
+
+    public async Task<IEnumerable<S3Object>> GetS3ObjectsByCustodianCodeAsync(string custodianCode)
+    {
+        try
+        {
+            var s3Client = new AmazonS3Client(RegionEndpoint.GetBySystemName(config.Region));
+            var request = new ListObjectsV2Request
+            {
+                BucketName = config.BucketName,
+                Prefix = custodianCode + "/",
+            };
+            var files = await s3Client.ListObjectsV2Async(request);
+
+            return files.S3Objects;
+        }
+        catch (AmazonS3Exception ex)
+        { 
+            logger.LogError
+            (
+                "AWS S3 error when listing CSV files from bucket: \"{BucketName}\", custodian code: \"{CustodianCode}\". Message: \"{Message}\"",
+                config.BucketName,
+                custodianCode,
+                ex.Message
+            );
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError
+            (
+                "Error when listing CSV files from bucket: \"{BucketName}\", custodian code: \"{CustodianCode}\". Message: \"{Message}\"",
+                config.BucketName,
+                custodianCode,
+                ex.Message
+            );
+            throw;
+        }
+    }
+}

--- a/HerPortal.BusinessLogic/ExternalServices/S3FileReader/S3FileReaderConfiguration.cs
+++ b/HerPortal.BusinessLogic/ExternalServices/S3FileReader/S3FileReaderConfiguration.cs
@@ -1,0 +1,12 @@
+﻿using Amazon;
+
+namespace HerPublicWebsite.BusinessLogic.ExternalServices.S3FileWriter;
+
+public class S3FileReaderConfiguration
+{
+    public const string ConfigSection = "S3";
+
+    public string BucketName { get; set; }
+
+    public string Region { get; set; }
+}

--- a/HerPortal.BusinessLogic/HerPortal.BusinessLogic.csproj
+++ b/HerPortal.BusinessLogic/HerPortal.BusinessLogic.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="AWSSDK.S3" Version="3.7.104.20" />
       <PackageReference Include="CabinetOffice.GovUkDesignSystem" Version="1.0.0-922f9ad" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>

--- a/HerPortal.BusinessLogic/Services/S3ReferralFileKeyService.cs
+++ b/HerPortal.BusinessLogic/Services/S3ReferralFileKeyService.cs
@@ -1,0 +1,58 @@
+﻿using System.Text.RegularExpressions;
+using HerPortal.BusinessLogic.Models;
+using Microsoft.Extensions.Logging;
+
+namespace HerPublicWebsite.BusinessLogic.Services.S3ReferralFileKeyGenerator;
+
+public class S3ReferralFileKeyService
+{
+    private readonly ILogger logger;
+
+    public S3ReferralFileKeyService(ILogger<S3ReferralFileKeyService> logger)
+    {
+        this.logger = logger;
+    }
+
+    public string GetS3KeyFromData(string custodianCode, int year, int month)
+    {
+        if (!LocalAuthorityData.LocalAuthorityNamesByCustodianCode.ContainsKey(custodianCode))
+        {
+            throw new ArgumentException("Invalid custodian code: " + custodianCode);
+        }
+
+        if (year is < 1000 or > 9999)
+        {
+            throw new ArgumentException("Invalid year: " + year);
+        }
+
+        if (month is < 1 or > 12)
+        {
+            throw new ArgumentException("Invalid month: " + month);
+        }
+
+        return $"{custodianCode}/{year}_{month:D2}.csv";
+    }
+
+    public (string CustodianCode, int Year, int Month) GetDataFromS3Key(string s3Key)
+    {
+        var s3KeyRegex = new Regex(@"^(?<custodianCode>\d+)/(?<year>\d+)_(?<month>\d+)\.csv$");
+        
+        if (!s3KeyRegex.IsMatch(s3Key))
+        {
+            logger.LogError("Could not extract custodian code, year, or month from S3 key \"{S3Key}\"", s3Key);
+            throw new ArgumentOutOfRangeException
+            (
+                nameof(s3Key),
+                s3Key,
+                $"Could not extract custodian code, year, or month from S3 key \"{s3Key}\""
+            );
+        }
+
+        var match = s3KeyRegex.Match(s3Key);
+        var custodianCode = match.Groups["custodianCode"].Value;
+        var year = int.Parse(match.Groups["year"].Value);
+        var month = int.Parse(match.Groups["month"].Value);
+
+        return (custodianCode, year, month);
+    }
+}

--- a/HerPortal.UnitTests/BusinessLogic/Services/S3ReferralFileKeyGeneratorTests.cs
+++ b/HerPortal.UnitTests/BusinessLogic/Services/S3ReferralFileKeyGeneratorTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using FluentAssertions;
+using HerPublicWebsite.BusinessLogic.Services.S3ReferralFileKeyGenerator;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Moq;
+
+namespace Tests.BusinessLogic.Services;
+
+[TestFixture]
+public class S3ReferralFileKeyGeneratorTests
+{
+    private Mock<ILogger<S3ReferralFileKeyService>> mockLogger;
+    
+    [SetUp]
+    public void Setup()
+    {
+        mockLogger = new Mock<ILogger<S3ReferralFileKeyService>>();
+    }
+    
+    [TestCase("5210", 2023, 1, "5210/2023_01.csv")]
+    [TestCase("505", 2024, 5, "505/2024_05.csv")]
+    [TestCase("4215", 2020, 12, "4215/2020_12.csv")]
+    public void S3ReferralFileKeyService_WhenGivenCustodianCodeYearAndMonth_ConstructsTheS3Key
+    (
+        string custodianCode,
+        int year,
+        int month,
+        string expectedS3Key
+    ) {
+        // Arrange
+        var underTest = new S3ReferralFileKeyService(mockLogger.Object);
+        
+        // Act
+        var result = underTest.GetS3KeyFromData(custodianCode, year, month);
+        
+        // Assert
+        result.Should().Be(expectedS3Key);
+    }
+    
+    [TestCase("5210/2023_01.csv", "5210", 2023, 1)]
+    [TestCase("505/2024_05.csv", "505", 2024, 5)]
+    [TestCase("4215/2020_12.csv", "4215", 2020, 12)]
+    public void S3ReferralFileKeyService_WhenGivenS3Key_ExtractsTheCustodianCodeYearAndMonth
+    (
+        string s3Key,
+        string expectedCustodianCode,
+        int expectedYear,
+        int expectedMonth
+    ) {
+        // Arrange
+        var underTest = new S3ReferralFileKeyService(mockLogger.Object);
+        
+        // Act
+        var result = underTest.GetDataFromS3Key(s3Key);
+        
+        // Assert
+        result.CustodianCode.Should().Be(expectedCustodianCode);
+        result.Year.Should().Be(expectedYear);
+        result.Month.Should().Be(expectedMonth);
+    }
+    
+    [TestCase("a")]
+    [TestCase("a.csv")]
+    [TestCase("42152020_12.csv")]
+    [TestCase("4215202012.csv")]
+    [TestCase("42152020/12.csv")]
+    [TestCase("4215/12.csv")]
+    [TestCase("505/2024_05")]
+    public void S3ReferralFileKeyService_WhenGivenMalformedS3Key_ThrowsArgumentOutOfRangeException
+    (
+        string s3Key
+    ) {
+        // Arrange
+        var underTest = new S3ReferralFileKeyService(mockLogger.Object);
+        
+        // Act
+        var act = () => underTest.GetDataFromS3Key(s3Key);
+        
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/HerPortal.UnitTests/BusinessLogic/Services/S3ReferralFileKeyServiceTests.cs
+++ b/HerPortal.UnitTests/BusinessLogic/Services/S3ReferralFileKeyServiceTests.cs
@@ -8,7 +8,7 @@ using Moq;
 namespace Tests.BusinessLogic.Services;
 
 [TestFixture]
-public class S3ReferralFileKeyGeneratorTests
+public class S3ReferralFileKeyServiceTests
 {
     private Mock<ILogger<S3ReferralFileKeyService>> mockLogger;
     

--- a/HerPortal.UnitTests/HerPortal.UnitTests.csproj
+++ b/HerPortal.UnitTests/HerPortal.UnitTests.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.6.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
         <PackageReference Include="coverlet.collector" Version="3.1.0" />
@@ -16,10 +17,6 @@
 
     <ItemGroup>
       <ProjectReference Include="..\HerPortal\HerPortal.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="BusinessLogic\Services\" />
     </ItemGroup>
 
 </Project>

--- a/HerPortal.UnitTests/Website/ExternalServices/CsvFiles/CsvFileDataTests.cs
+++ b/HerPortal.UnitTests/Website/ExternalServices/CsvFiles/CsvFileDataTests.cs
@@ -8,31 +8,6 @@ namespace Tests.Website.ExternalServices.CsvFiles;
 [TestFixture]
 public class CsvFileDataTests
 {
-    [TestCase("5210", 2023, 1, "5210/2023_01.csv")]
-    [TestCase("505", 2024, 5, "505/2024_05.csv")]
-    [TestCase("4215", 2020, 12, "4215/2020_12.csv")]
-    public void CsvFileData_WhenGivenCustodianCodeYearAndMonth_ConstructsTheS3Key
-    (
-        string custodianCode,
-        int year,
-        int month,
-        string expectedS3Key
-    ) {
-        // Arrange/Act
-        var underTest = new CsvFileData
-        (
-            custodianCode,
-            month,
-            year,
-            new DateTime(2024, 1, 1),
-            null,
-            true
-        );
-        
-        // Assert
-        underTest.S3Key.Should().Be(expectedS3Key);
-    }
-    
     [Test]
     public void CsvFileData_WhenLastDownloadedIsNull_SetsHasUpdatedSinceLastDownloadedToTrue()
     {

--- a/HerPortal/ExternalServices/CsvFiles/CsvFileData.cs
+++ b/HerPortal/ExternalServices/CsvFiles/CsvFileData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Amazon.S3.Model;
 
 namespace HerPortal.ExternalServices.CsvFiles;
 
@@ -15,8 +16,6 @@ public class CsvFileData
     //   it will always have been updated since it was last downloaded.
     public bool HasUpdatedSinceLastDownload => !LastDownloaded.HasValue || LastDownloaded.Value.CompareTo(LastUpdated) < 0;
     public bool HasApplications { get; }
-    
-    public string S3Key => $"{CustodianCode}/{Year}_{Month:D2}.csv";
 
     public CsvFileData
     (

--- a/HerPortal/ExternalServices/CsvFiles/CsvFileGetter.cs
+++ b/HerPortal/ExternalServices/CsvFiles/CsvFileGetter.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using HerPortal.BusinessLogic.Models;
+using HerPortal.Data.ExternalServices.S3FileReader;
+using HerPortal.DataStores;
+using HerPublicWebsite.BusinessLogic.Services.S3ReferralFileKeyGenerator;
+
+namespace HerPortal.ExternalServices.CsvFiles;
+
+public class CsvFileGetter : ICsvFileGetter
+{
+    private readonly CsvFileDownloadDataStore csvFileDownloadDataStore;
+    private readonly S3ReferralFileKeyService keyService;
+    private readonly IS3FileReader s3FileReader;
+
+    public CsvFileGetter
+    (
+        CsvFileDownloadDataStore csvFileDownloadDataStore,
+        S3ReferralFileKeyService keyService,
+        IS3FileReader s3FileReader
+    ) {
+        this.csvFileDownloadDataStore = csvFileDownloadDataStore;
+        this.keyService = keyService;
+        this.s3FileReader = s3FileReader;
+    }
+    
+    public async Task<IEnumerable<CsvFileData>> GetByCustodianCodesAsync(IEnumerable<string> custodianCodes, int userId)
+    {
+        var downloads = await csvFileDownloadDataStore.GetLastCsvFileDownloadsAsync(userId);
+        var files = new List<CsvFileData>();
+
+        foreach (var custodianCode in custodianCodes)
+        {
+            var s3Objects = await s3FileReader.GetS3ObjectsByCustodianCodeAsync(custodianCode);
+            files.AddRange(s3Objects.Select(s3O =>
+                {
+                    var data = keyService.GetDataFromS3Key(s3O.Key);
+                    var downloadData = downloads.SingleOrDefault(d =>
+                        d.CustodianCode == data.CustodianCode
+                        && d.Year == data.Year
+                        && d.Month == data.Month
+                    );
+                    return new CsvFileData
+                    (
+                        data.CustodianCode,
+                        data.Month,
+                        data.Year,
+                        s3O.LastModified,
+                        downloadData?.LastDownloaded,
+                        true
+                    );
+                }
+            ));
+        }
+
+        return files;
+    }
+
+    public async Task<Stream> GetFileForDownloadAsync(string custodianCode, int year, int month, int userId)
+    {
+        if (!LocalAuthorityData.LocalAuthorityNamesByCustodianCode.ContainsKey(custodianCode))
+        {
+            throw new ArgumentOutOfRangeException(nameof(custodianCode), custodianCode,
+                "Given custodian code is not valid");
+        }
+        
+        // Notably, we can't confirm a download, so it's possible that we mark a file as downloaded
+        //   but the user has some sort of issue and doesn't get it
+        // We put this line as late as possible in the method for this reason
+        await csvFileDownloadDataStore.MarkCsvFileAsDownloadedAsync(custodianCode, year, month, userId);
+        
+        return await s3FileReader.ReadFileAsync(custodianCode, year, month);
+    }
+}

--- a/HerPortal/Startup.cs
+++ b/HerPortal/Startup.cs
@@ -11,11 +11,14 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using HerPortal.Data;
+using HerPortal.Data.ExternalServices.S3FileReader;
 using HerPortal.DataStores;
 using HerPortal.ErrorHandling;
 using HerPortal.ExternalServices.CsvFiles;
 using HerPortal.ExternalServices.EmailSending;
 using HerPortal.Services;
+using HerPublicWebsite.BusinessLogic.ExternalServices.S3FileWriter;
+using HerPublicWebsite.BusinessLogic.Services.S3ReferralFileKeyGenerator;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.HttpLogging;
@@ -41,13 +44,14 @@ namespace HerPortal
             services.AddScoped<CsvFileDownloadDataStore>();
             services.AddScoped<UserDataStore>();
             services.AddScoped<IDataAccessProvider, DataAccessProvider>();
-            services.AddScoped<ICsvFileGetter, DummyCsvFileGetter>();
+            services.AddScoped<ICsvFileGetter, CsvFileGetter>();
             services.AddSingleton<StaticAssetsVersioningService>();
             // This allows encrypted cookies to be understood across multiple web server instances
             services.AddDataProtection().PersistKeysToDbContext<HerDbContext>();
 
             ConfigureGovUkNotify(services);
             ConfigureDatabaseContext(services);
+            ConfigureS3FileReader(services);
 
             services.AddControllersWithViews(options =>
             {
@@ -90,6 +94,14 @@ namespace HerPortal
             services.AddScoped<IEmailSender, GovUkNotifyApi>();
             services.Configure<GovUkNotifyConfiguration>(
                 configuration.GetSection(GovUkNotifyConfiguration.ConfigSection));
+        }
+        
+        private void ConfigureS3FileReader(IServiceCollection services)
+        {
+            services.Configure<S3FileReaderConfiguration>(
+                configuration.GetSection(S3FileReaderConfiguration.ConfigSection));
+            services.AddScoped<IS3FileReader, S3FileReader>();
+            services.AddScoped<S3ReferralFileKeyService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/HerPortal/appsettings.json
+++ b/HerPortal/appsettings.json
@@ -22,5 +22,10 @@
     "GoogleAnalytics": {
         "CookieName": "_ga",
         "BaseUrl": "https://www.google-analytics.com"
+    },
+    
+    "S3": {
+        "BucketName": "desnz-her-portal-referrals",
+        "Region": "eu-west-2"
     }
 }


### PR DESCRIPTION
Connect the referrals portal to the S3 buckets. You can now download the files straight from S3, and they get correctly filtered by custodian code.