### PR TITLE
BH-769: Firm up cookie setting safety

### DIFF
--- a/HerPortal/Startup.cs
+++ b/HerPortal/Startup.cs
@@ -21,6 +21,7 @@ using HerPortal.Services;
 using HerPublicWebsite.BusinessLogic.Services.S3ReferralFileKeyGenerator;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.AspNetCore.HttpOverrides;
 using GlobalConfiguration = HerPortal.BusinessLogic.GlobalConfiguration;
@@ -71,7 +72,11 @@ namespace HerPortal
                 options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
             })
-            .AddCookie()
+            .AddCookie(options =>
+            {
+                options.Cookie.HttpOnly = true;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            })
             .AddOpenIdConnect(options =>
             {
                 options.ResponseType = "code";
@@ -82,6 +87,10 @@ namespace HerPortal
                 options.Scope.Add("openid");
                 options.Scope.Add("profile");
                 options.SaveTokens = true;
+                options.NonceCookie.HttpOnly = true;
+                options.NonceCookie.SecurePolicy = CookieSecurePolicy.Always;
+                options.CorrelationCookie.HttpOnly = true;
+                options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
             });
 
             services.AddHsts(options =>


### PR DESCRIPTION
All three cookies now have the advised settings:
![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta/assets/4410524/94f49887-b8c1-4b1c-83c1-5107dceb3020)
