### PR TITLE
Beisher 764 session timeout2

### DIFF
--- a/HerPortal/Controllers/SignOutController.cs
+++ b/HerPortal/Controllers/SignOutController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authentication;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 
 namespace HerPortal.Controllers;
@@ -6,9 +7,9 @@ namespace HerPortal.Controllers;
 [Route("sign-out")]
 public class SignOutController : Controller
 {
-    public IActionResult Index()
+    public async Task<IActionResult> Index()
     {
-        HttpContext.SignOutAsync();
+        await HttpContext.SignOutAsync();
 
         return RedirectToAction("Index", "Home");
     }

--- a/HerPortal/Startup.cs
+++ b/HerPortal/Startup.cs
@@ -23,8 +23,8 @@ using HerPublicWebsite.BusinessLogic.Services.S3ReferralFileKeyGenerator;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using GlobalConfiguration = HerPortal.BusinessLogic.GlobalConfiguration;
 
 namespace HerPortal
@@ -75,19 +75,26 @@ namespace HerPortal
             })
             .AddCookie(options =>
             {
+                options.ExpireTimeSpan = TimeSpan.FromMinutes(15);
+                options.SlidingExpiration = true;
                 options.Cookie.HttpOnly = true;
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+                options.Cookie.SameSite = SameSiteMode.Lax;
             })
             .AddOpenIdConnect(options =>
             {
-                options.ResponseType = "code";
+                options.NonceCookie.SameSite = SameSiteMode.Lax;
+                options.CorrelationCookie.SameSite = SameSiteMode.Lax;
+                
+                options.ResponseType = OpenIdConnectResponseType.Code;
                 options.MetadataAddress = configuration["Authentication:Cognito:MetadataAddress"];
                 options.ClientId = configuration["Authentication:Cognito:ClientId"];
                 options.ClientSecret = configuration["Authentication:Cognito:ClientSecret"];
                 options.Scope.Add("email");
                 options.Scope.Add("openid");
                 options.Scope.Add("profile");
-                options.SaveTokens = true;
+                options.SaveTokens = true; // Save tokens issued to encrypted cookies
+                options.UseTokenLifetime = false; // Don't override the cookie lifetime set above
                 options.NonceCookie.HttpOnly = true;
                 options.NonceCookie.SecurePolicy = CookieSecurePolicy.Always;
                 options.CorrelationCookie.HttpOnly = true;

--- a/HerPortal/Views/StaticPages/PrivacyPolicy.cshtml
+++ b/HerPortal/Views/StaticPages/PrivacyPolicy.cshtml
@@ -23,7 +23,7 @@
             Your data
         </h2>
         <p class="govuk-body">
-            The HUG 2 Eligibility Checker portal users your email address to identify your user account and records:
+            The HUG 2 Eligibility Checker portal uses your email address to identify your user account, and also records:
         </p>
         <ul class="govuk-list govuk-list--bullet">
             <li class="govuk-body">The local authority areas you can access</li>

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Fill in the opened `secrets.json` file with:
             "ClientId": "<app client id from AWS Cognito>",
             "ClientSecret": "<app client secret from AWS Cognito>",
             "MetadataAddress": "https://cognito-idp.{your-region-id}.amazonaws.com/{your-user-pool-id}/.well-known/openid-configuration",
-            "SignOutUrl": "https://{cognito-client-base-url}/logout?client_id={client-id}&logout_uri=https://localhost:5001/portal/sign-out"
+            "SignOutUrl": "{cognito-domain}/logout?client_id={client-id}&logout_uri=https://localhost:5001/portal/sign-out"
         }
     },
 


### PR DESCRIPTION
It looks like we can't do better than a up to 1 hour timeout at the moment due to a Cognito limitation.

With these changes we will log the user out of our site after 15 minutes and send them to the Cognito login page. However, if that happens less than one hour after they originally signed in the Cognito login page will use some cookies it set on the original login to automatically login the user and send them straight back to our site.

Once those Cognito cookies expire the 15 minute idle timeout works as expected.