### PR TITLE
PC-597 fix crash with sparse local authority records in consortium

### DIFF
--- a/HerPortal.BusinessLogic/ExternalServices/S3FileReader/IS3FileReader.cs
+++ b/HerPortal.BusinessLogic/ExternalServices/S3FileReader/IS3FileReader.cs
@@ -6,4 +6,5 @@ public interface IS3FileReader
 {
     public Task<Stream> ReadFileAsync(string custodianCode, int year, int month);
     public Task<IEnumerable<S3Object>> GetS3ObjectsByCustodianCodeAsync(string custodianCode);
+    public Task<bool> FileExistsAsync(string custodianCode, int year, int month);
 }

--- a/HerPortal.BusinessLogic/ExternalServices/S3FileReader/S3FileReader.cs
+++ b/HerPortal.BusinessLogic/ExternalServices/S3FileReader/S3FileReader.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.S3;
+﻿using Amazon.Runtime;
+using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Transfer;
 using HerPublicWebsite.BusinessLogic.Services.S3ReferralFileKeyGenerator;
@@ -101,12 +102,20 @@ public class S3FileReader : IS3FileReader
     public async Task<bool> FileExistsAsync(string custodianCode, int year, int month)
     {
         var key = keyService.GetS3KeyFromData(custodianCode, year, month);
-        var request = new ListObjectsV2Request
+        var request = new GetObjectMetadataRequest()
         {
             BucketName = config.BucketName,
-            Prefix = key,
+            Key = key,
         };
-        var files = await s3Client.ListObjectsV2Async(request);
-        return files.KeyCount > 0;
+
+        try
+        {
+            await s3Client.GetObjectMetadataAsync(request);
+            return true;
+        }
+        catch (AmazonServiceException)
+        {
+            return false;
+        }
     }
 }

--- a/HerPortal.BusinessLogic/ExternalServices/S3FileReader/S3FileReader.cs
+++ b/HerPortal.BusinessLogic/ExternalServices/S3FileReader/S3FileReader.cs
@@ -97,4 +97,16 @@ public class S3FileReader : IS3FileReader
             throw;
         }
     }
+
+    public async Task<bool> FileExistsAsync(string custodianCode, int year, int month)
+    {
+        var key = keyService.GetS3KeyFromData(custodianCode, year, month);
+        var request = new ListObjectsV2Request
+        {
+            BucketName = config.BucketName,
+            Prefix = key,
+        };
+        var files = await s3Client.ListObjectsV2Async(request);
+        return files.KeyCount > 0;
+    }
 }

--- a/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
+++ b/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Security;
+using Amazon.S3;
 using CsvHelper;
 using CsvHelper.Configuration.Attributes;
 using HerPortal.BusinessLogic.ExternalServices.S3FileReader;
@@ -193,6 +194,11 @@ public class CsvFileService : ICsvFileService
         
         foreach (var custodianCode in ConsortiumData.ConsortiumCustodianCodesIdsByConsortiumCode[consortiumCode])
         {
+            if (!await s3FileReader.FileExistsAsync(custodianCode, year, month))
+            {
+                continue;
+            }
+            
             var localAuthorityFile = await GetLocalAuthorityFileForDownloadAsync(custodianCode, year, month, userEmailAddress);
 
             using var reader = new StreamReader(localAuthorityFile);

--- a/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
+++ b/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
@@ -186,7 +186,7 @@ public class CsvFileService : ICsvFileService
         if (!ConsortiumData.ConsortiumNamesByConsortiumCode.ContainsKey(consortiumCode))
         {
             throw new ArgumentOutOfRangeException(nameof(consortiumCode), consortiumCode,
-                "Given custodian code is not valid");
+                "Given consortium code is not valid");
         }
 
         var referralRequests = new List<CsvReferralRequest>();

--- a/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
+++ b/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Security;
-using Amazon.S3;
 using CsvHelper;
 using CsvHelper.Configuration.Attributes;
 using HerPortal.BusinessLogic.ExternalServices.S3FileReader;


### PR DESCRIPTION
on develop, it was noticed that there was a crash sometimes when downloading data for a consortium

the issue was isolated as that it is possible (although unlikely) that a local authority has no referrals in a month. as such no file will be exported for it

the consortium code when reading all local authority csvs would not check whether an export had been created for a given csv in a month, causing a crash in the above case

this is fixed by implementing a check that the csv file does indeed exist

a test confirming this is also included