### PR TITLE
PC-1007: Adding the LA name to the CSV downloaded by Consortia

### DIFF
--- a/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
+++ b/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
@@ -61,8 +61,8 @@ public class CsvFileService : ICsvFileService
         [Optional]
         public string Tenure { get; set; }
         [Optional] // optional as it doesnt appear in input csv
-        [Name("Custodian Code")]
-        public string CustodianCode { get; set; }
+        [Name("Local Authority")]
+        public string LocalAuthority { get; set; }
     }
 
     public CsvFileService
@@ -216,6 +216,7 @@ public class CsvFileService : ICsvFileService
             }
             
             var localAuthorityFile = await GetLocalAuthorityFileForDownloadAsync(custodianCode, year, month, userEmailAddress);
+            var localAuthorityName = LocalAuthorityData.LocalAuthorityNamesByCustodianCode[custodianCode];
 
             using var reader = new StreamReader(localAuthorityFile);
             using var localAuthorityCsv = new CsvReader(reader, CultureInfo.InvariantCulture);
@@ -223,7 +224,7 @@ public class CsvFileService : ICsvFileService
                 .GetRecords<CsvReferralRequest>()
                 .Select(record =>
                 {
-                    record.CustodianCode = custodianCode;
+                    record.LocalAuthority = localAuthorityName;
                     return record;
                 })
             );


### PR DESCRIPTION
closes [PC-1007](https://beisdigital.atlassian.net/browse/PC-1007)

changes the downloaded csv to contain a "Local Authority" field rather than a "Custodian Code" field

as there are no tests for the function to generate this csv (which would require some tricky mocking as the input for this function is other local csv files), no tests have been included