### PR TITLE
PC-1084 build consortium admin model into business logic

### DIFF
--- a/HerPortal.BusinessLogic/IDataAccessProvider.cs
+++ b/HerPortal.BusinessLogic/IDataAccessProvider.cs
@@ -9,5 +9,4 @@ public interface IDataAccessProvider
     public Task<IEnumerable<User>> GetAllActiveUsersAsync();
     public Task<List<CsvFileDownload>> GetCsvFileDownloadDataForUserAsync(int userId);
     public Task MarkCsvFileAsDownloadedAsync(string custodianCode, int year, int month, int userId);
-    public List<string> GetConsortiumCodesForUser(User user);
 }

--- a/HerPortal.BusinessLogic/Models/User.cs
+++ b/HerPortal.BusinessLogic/Models/User.cs
@@ -11,13 +11,17 @@ public class User
 
     public List<string> GetAdministeredCustodianCodes()
     {
-        var consortiumCodes = Consortia.Select(consortium => consortium.ConsortiumCode).ToList();
-        var custodianCodes = LocalAuthorities.Select(la => la.CustodianCode).ToList();
+        var consortiumCodes = Consortia.Select(consortium => consortium.ConsortiumCode);
+        var custodianCodes = LocalAuthorities.Select(la => la.CustodianCode);
 
-        return consortiumCodes.SelectMany(consortiumCode => 
+        return consortiumCodes.SelectMany(consortiumCode =>
                 ConsortiumData.ConsortiumCustodianCodesIdsByConsortiumCode[consortiumCode])
-            .Distinct()
             .Union(custodianCodes)
             .ToList();
+    }
+
+    public List<string> GetAdministeredConsortiumCodes()
+    {
+        return Consortia.Select(c => c.ConsortiumCode).ToList();
     }
 }

--- a/HerPortal.BusinessLogic/Models/User.cs
+++ b/HerPortal.BusinessLogic/Models/User.cs
@@ -9,13 +9,14 @@ public class User
     public List<LocalAuthority> LocalAuthorities { get; set; }
     public List<Consortium> Consortia { get; set; }
 
-    public List<string> GetAdministratedCustodianCodes()
+    public List<string> GetAdministeredCustodianCodes()
     {
         var consortiumCodes = Consortia.Select(consortium => consortium.ConsortiumCode).ToList();
         var custodianCodes = LocalAuthorities.Select(la => la.CustodianCode).ToList();
-        return LocalAuthorityData.LocalAuthorityConsortiumCodeByCustodianCode
-            .Where(codes => consortiumCodes.Contains(codes.Value))
-            .Select(codes => codes.Key)
+
+        return consortiumCodes.SelectMany(consortiumCode => 
+                ConsortiumData.ConsortiumCustodianCodesIdsByConsortiumCode[consortiumCode])
+            .Distinct()
             .Union(custodianCodes)
             .ToList();
     }

--- a/HerPortal.BusinessLogic/Models/User.cs
+++ b/HerPortal.BusinessLogic/Models/User.cs
@@ -8,4 +8,15 @@ public class User
 
     public List<LocalAuthority> LocalAuthorities { get; set; }
     public List<Consortium> Consortia { get; set; }
+    
+    public List<string> GetAdministratedCustodianCodes()
+    {
+        var consortiumCodes = Consortia.Select(consortium => consortium.ConsortiumCode).ToList();
+        var custodianCodes = LocalAuthorities.Select(la => la.CustodianCode).ToList();
+        return LocalAuthorityData.LocalAuthorityConsortiumCodeByCustodianCode
+            .Where(codes => consortiumCodes.Contains(codes.Value))
+            .Select(codes => codes.Key)
+            .Union(custodianCodes)
+            .ToList();
+    }
 }

--- a/HerPortal.BusinessLogic/Models/User.cs
+++ b/HerPortal.BusinessLogic/Models/User.cs
@@ -9,19 +9,18 @@ public class User
     public List<LocalAuthority> LocalAuthorities { get; set; }
     public List<Consortium> Consortia { get; set; }
 
-    public List<string> GetAdministeredCustodianCodes()
+    public IEnumerable<string> GetAdministeredCustodianCodes()
     {
         var consortiumCodes = Consortia.Select(consortium => consortium.ConsortiumCode);
         var custodianCodes = LocalAuthorities.Select(la => la.CustodianCode);
 
         return consortiumCodes.SelectMany(consortiumCode =>
                 ConsortiumData.ConsortiumCustodianCodesIdsByConsortiumCode[consortiumCode])
-            .Union(custodianCodes)
-            .ToList();
+            .Union(custodianCodes);
     }
 
-    public List<string> GetAdministeredConsortiumCodes()
+    public IEnumerable<string> GetAdministeredConsortiumCodes()
     {
-        return Consortia.Select(c => c.ConsortiumCode).ToList();
+        return Consortia.Select(c => c.ConsortiumCode);
     }
 }

--- a/HerPortal.BusinessLogic/Models/User.cs
+++ b/HerPortal.BusinessLogic/Models/User.cs
@@ -8,7 +8,7 @@ public class User
 
     public List<LocalAuthority> LocalAuthorities { get; set; }
     public List<Consortium> Consortia { get; set; }
-    
+
     public List<string> GetAdministratedCustodianCodes()
     {
         var consortiumCodes = Consortia.Select(consortium => consortium.ConsortiumCode).ToList();

--- a/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
+++ b/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
@@ -84,7 +84,7 @@ public class CsvFileService : ICsvFileService
         // Make sure that we only return file data for files that the user currently has access to
         var user = await dataAccessProvider.GetUserByEmailAsync(userEmailAddress);
         var custodianCodes = user.GetAdministeredCustodianCodes();
-        var consortiumCodes = user.Consortia.Select(c => c.ConsortiumCode).ToList();
+        var consortiumCodes = user.GetAdministeredConsortiumCodes();
         
         var localAuthoritiesFileData = await BuildCsvFileDataForLocalAuthorities(user, custodianCodes);
         var consortiaTransformedFileData = TransformFileDataForConsortia(consortiumCodes, localAuthoritiesFileData);
@@ -204,7 +204,7 @@ public class CsvFileService : ICsvFileService
     {
         // Important! First ensure the logged-in user is allowed to access this data
         var userData = await dataAccessProvider.GetUserByEmailAsync(userEmailAddress);
-        var consortiumCodes = userData.Consortia.Select(c => c.ConsortiumCode).ToList();
+        var consortiumCodes = userData.GetAdministeredConsortiumCodes();
 
         if (!consortiumCodes.Contains(consortiumCode))
         {

--- a/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
+++ b/HerPortal.BusinessLogic/Services/CsvFileService/CsvFileService.cs
@@ -83,7 +83,7 @@ public class CsvFileService : ICsvFileService
     {
         // Make sure that we only return file data for files that the user currently has access to
         var user = await dataAccessProvider.GetUserByEmailAsync(userEmailAddress);
-        var currentCustodianCodes = user.LocalAuthorities.Select(la => la.CustodianCode);
+        var currentCustodianCodes = user.GetAdministratedCustodianCodes();
         
         var downloads = await dataAccessProvider.GetCsvFileDownloadDataForUserAsync(user.Id);
         var files = new List<CsvFileData>();
@@ -167,7 +167,7 @@ public class CsvFileService : ICsvFileService
     {
         // Important! First ensure the logged-in user is allowed to access this data
         var userData = await dataAccessProvider.GetUserByEmailAsync(userEmailAddress);
-        if (!userData.LocalAuthorities.Any(la => la.CustodianCode == custodianCode))
+        if (userData.GetAdministratedCustodianCodes().All(custodianCodes => custodianCodes != custodianCode))
         {
             // We don't want to log the User's email address for GDPR reasons, but the ID is fine.
             throw new SecurityException(

--- a/HerPortal.BusinessLogic/Services/UserService.cs
+++ b/HerPortal.BusinessLogic/Services/UserService.cs
@@ -22,9 +22,4 @@ public class UserService
     {
         await dataAccessProvider.MarkUserAsHavingLoggedInAsync(userId);
     }
-
-    public List<string> GetConsortiumCodesForUser(User user)
-    {
-        return dataAccessProvider.GetConsortiumCodesForUser(user);
-    }
 }

--- a/HerPortal.Data/DataAccessProvider.cs
+++ b/HerPortal.Data/DataAccessProvider.cs
@@ -109,9 +109,9 @@ public class DataAccessProvider : IDataAccessProvider
     {
         var userLocalAuthorities = user.LocalAuthorities.Select(la => la.CustodianCode);
         var userConsortia = user.Consortia.Select(consortium => consortium.ConsortiumCode);
-        
+
         // user is a consortium manager if they are a manager of all LAs in that consortium
-        return  ConsortiumData.ConsortiumCustodianCodesIdsByConsortiumCode
+        return ConsortiumData.ConsortiumCustodianCodesIdsByConsortiumCode
             .Where(pair => pair.Value.All(consortiumLa => userLocalAuthorities.Contains(consortiumLa)))
             .Select(pair => pair.Key)
             //Include all explicitly listed consortium codes

--- a/HerPortal.Data/DataAccessProvider.cs
+++ b/HerPortal.Data/DataAccessProvider.cs
@@ -45,8 +45,6 @@ public class DataAccessProvider : IDataAccessProvider
     {
         return await context.Users
             .Where(u => u.HasLoggedIn)
-            .Include(u => u.LocalAuthorities)
-            .Include(u => u.Consortia)
             .ToListAsync();
     }
 
@@ -103,19 +101,5 @@ public class DataAccessProvider : IDataAccessProvider
         await context.AuditDownloads.AddAsync(auditDownload);
         
         await context.SaveChangesAsync();
-    }
-
-    public List<string> GetConsortiumCodesForUser(User user)
-    {
-        var userLocalAuthorities = user.LocalAuthorities.Select(la => la.CustodianCode);
-        var userConsortia = user.Consortia.Select(consortium => consortium.ConsortiumCode);
-
-        // user is a consortium manager if they are a manager of all LAs in that consortium
-        return ConsortiumData.ConsortiumCustodianCodesIdsByConsortiumCode
-            .Where(pair => pair.Value.All(consortiumLa => userLocalAuthorities.Contains(consortiumLa)))
-            .Select(pair => pair.Key)
-            //Include all explicitly listed consortium codes
-            .Union(userConsortia)
-            .ToList();
     }
 }

--- a/HerPortal.UnitTests/Builders/UserBuilder.cs
+++ b/HerPortal.UnitTests/Builders/UserBuilder.cs
@@ -29,6 +29,12 @@ public class UserBuilder
         user.LocalAuthorities = localAuthorities;
         return this;
     }
+    
+    public UserBuilder WithConsortia(List<Consortium> consortia)
+    {
+        user.Consortia = consortia;
+        return this;
+    }
 
     public UserBuilder WithHasLoggedIn(bool hasLoggedIn)
     {

--- a/HerPortal.UnitTests/Builders/UserBuilder.cs
+++ b/HerPortal.UnitTests/Builders/UserBuilder.cs
@@ -14,7 +14,8 @@ public class UserBuilder
             Id = 13,
             EmailAddress = emailAddress,
             HasLoggedIn = true,
-            LocalAuthorities = new List<LocalAuthority>()
+            LocalAuthorities = new List<LocalAuthority>(),
+            Consortia = new List<Consortium>()
         };
     }
 

--- a/HerPortal.UnitTests/BusinessLogic/Services/CsvFileService/CsvFileServiceTests.cs
+++ b/HerPortal.UnitTests/BusinessLogic/Services/CsvFileService/CsvFileServiceTests.cs
@@ -57,7 +57,6 @@ public class CsvFileServiceTests
         var user = GetUserWithLas("114", "910");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>());
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -98,7 +97,6 @@ public class CsvFileServiceTests
         var user = GetUserWithLas("114");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>());
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -139,7 +137,6 @@ public class CsvFileServiceTests
         var user = GetUserWithLas("114");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>());
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -193,7 +190,6 @@ public class CsvFileServiceTests
         var user = GetUserWithLas("114", "910");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>());
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -248,7 +244,6 @@ public class CsvFileServiceTests
         var user = GetUserWithLas("114", "910");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>());
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -302,7 +297,6 @@ public class CsvFileServiceTests
         var user = GetUserWithLas("114");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>());
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -352,7 +346,6 @@ public class CsvFileServiceTests
         var user = GetUserWithLas("114");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>());
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -389,7 +382,6 @@ public class CsvFileServiceTests
         var user = GetUserWithLas("114");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>());
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -423,10 +415,9 @@ public class CsvFileServiceTests
     public async Task GetFileDataForUserAsync_WhenCalledWithConsortium_ReturnsFileData()
     {
         // Arrange
-        var user = GetUserWithLas("660", "665");
+        var user = GetUserWithConsortia("C_0008");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>{"C_0008"});
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -481,10 +472,9 @@ public class CsvFileServiceTests
     public async Task GetFileDataForUserAsync_WhenCalledWithConsortium_ReturnsFileData_WithCorrectConsortiumDates()
     {
         // Arrange
-        var user = GetUserWithLas("660", "665");
+        var user = GetUserWithConsortia("C_0008");
         
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>{"C_0008"});
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -539,10 +529,9 @@ public class CsvFileServiceTests
     public async Task GetFileDataForUserAsync_WhenCalledWithConsortium_ReturnsFileData_EvenIfNotAllLasReportInTheMonth()
     {
         // Arrange
-        var user = GetUserWithLas("660", "665");
-        
+        var user = GetUserWithConsortia("C_0008");
+
         mockDataAccessProvider.Setup(dap => dap.GetUserByEmailAsync(user.EmailAddress)).ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>{"C_0008"});
         
         mockDataAccessProvider
             .Setup(dap => dap.GetCsvFileDownloadDataForUserAsync(user.Id))
@@ -577,12 +566,22 @@ public class CsvFileServiceTests
         result.Should().BeEquivalentTo(expectedResult);
     }
 
+    private User GetUserWithConsortia(params string[] consortia)
+    {
+        return new UserBuilder("test@example.com")
+            .WithConsortia(
+                consortia.Select(consortium => new Consortium
+                {
+                    ConsortiumCode = consortium
+                }).ToList())
+            .Build();
+    }
     
     private User GetUserWithLas(params string[] las)
     {
         return new UserBuilder("test@example.com")
             .WithLocalAuthorities(
-                las.Select(la => new LocalAuthority()
+                las.Select(la => new LocalAuthority
                 {
                     CustodianCode = la
                 }).ToList())

--- a/HerPortal.UnitTests/Helpers/ValidConsortiumGenerator.cs
+++ b/HerPortal.UnitTests/Helpers/ValidConsortiumGenerator.cs
@@ -1,0 +1,17 @@
+﻿namespace Tests.Helpers;
+
+using System.Collections.Generic;
+using System.Linq;
+using HerPortal.BusinessLogic.Models;
+
+public class ValidConsortiumGenerator
+{
+    public static IEnumerable<Consortium> GetConsortiaWithDifferentCodes(int count)
+    {
+        return ConsortiumData
+            .ConsortiumNamesByConsortiumCode
+            .Keys
+            .Take(count)
+            .Select(cc => new Consortium { ConsortiumCode = cc });
+    }
+}

--- a/HerPortal.UnitTests/Helpers/ValidConsortiumGenerator.cs
+++ b/HerPortal.UnitTests/Helpers/ValidConsortiumGenerator.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using HerPortal.BusinessLogic.Models;
 
-public class ValidConsortiumGenerator
+public static class ValidConsortiumGenerator
 {
     public static IEnumerable<Consortium> GetConsortiaWithDifferentCodes(int count)
     {

--- a/HerPortal.UnitTests/Website/Controllers/HomeControllerTests.cs
+++ b/HerPortal.UnitTests/Website/Controllers/HomeControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using HerPortal.BusinessLogic;
 using HerPortal.BusinessLogic.Models;

--- a/HerPortal.UnitTests/Website/Controllers/HomeControllerTests.cs
+++ b/HerPortal.UnitTests/Website/Controllers/HomeControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using HerPortal.BusinessLogic;
 using HerPortal.BusinessLogic.Models;
@@ -62,7 +63,6 @@ public class HomeFileControllerTests
         mockDataAccessProvider
             .Setup(dap => dap.GetUserByEmailAsync(EmailAddress))
             .ReturnsAsync(user);
-        mockDataAccessProvider.Setup(dap => dap.GetConsortiumCodesForUser(user)).Returns(new List<string>());
         mockCsvFileService
             .Setup(cfg => cfg.GetPaginatedFileDataForUserAsync(user.EmailAddress, new List<string> { "114"}, 1, 20))
             .ReturnsAsync(fileData);

--- a/HerPortal.UnitTests/Website/Models/HomepageViewModelTests.cs
+++ b/HerPortal.UnitTests/Website/Models/HomepageViewModelTests.cs
@@ -43,19 +43,42 @@ public class HomepageViewModelTests
         };
         
         // Act
-        var viewModel = new HomepageViewModel(user, new PaginatedFileData(), GetDummyPageLink, GetDummyDownloadLink, new List<string>());
+        var viewModel = new HomepageViewModel(user, new PaginatedFileData(), GetDummyPageLink, GetDummyDownloadLink);
         
         // Assert
         viewModel.ShouldShowBanner.Should().Be(shouldShowBanner);
     }
 
-    [TestCase(1, 0, false)]
-    [TestCase(2, 0, true)]
-    [TestCase(3, 0, true)]
-    [TestCase(4, 0, true)]
-    [TestCase(100, 0, true)]
-    [TestCase(0, 1, true)]
+    [TestCase(1, false)]
+    [TestCase(2, true)]
+    [TestCase(3, true)]
+    [TestCase(4, true)]
+    [TestCase(100, true)]
     public void HomepageViewModel_OnlyWhenUserHasOneLocalAuthority_ShouldNotShowFilters
+    (
+        int numberOfLas,
+        bool expected
+    ) {
+        // Arrange
+        var user = new User
+        {
+            HasLoggedIn = true,
+            LocalAuthorities = ValidLocalAuthorityGenerator
+                .GetLocalAuthoritiesWithDifferentCodes(numberOfLas)
+                .ToList(),
+            Consortia = ValidConsortiumGenerator.GetConsortiaWithDifferentCodes(0).ToList()
+        };
+        
+        // Act
+        var viewModel = new HomepageViewModel(user, new PaginatedFileData(), GetDummyPageLink, GetDummyDownloadLink);
+        
+        // Assert
+        viewModel.ShouldShowFilters.Should().Be(expected);
+    }
+    
+    [TestCase(0, 1, true)]
+    [TestCase(1, 1, true)]
+    public void HomepageViewModel_WhenUserHasConsortium_ShouldShowFilters
     (
         int numberOfLas,
         int numberOfConsortia,
@@ -72,7 +95,7 @@ public class HomepageViewModelTests
         };
         
         // Act
-        var viewModel = new HomepageViewModel(user, new PaginatedFileData(), GetDummyPageLink, GetDummyDownloadLink, new List<string>());
+        var viewModel = new HomepageViewModel(user, new PaginatedFileData(), GetDummyPageLink, GetDummyDownloadLink);
         
         // Assert
         viewModel.ShouldShowFilters.Should().Be(expected);

--- a/HerPortal.UnitTests/Website/Models/HomepageViewModelTests.cs
+++ b/HerPortal.UnitTests/Website/Models/HomepageViewModelTests.cs
@@ -48,12 +48,12 @@ public class HomepageViewModelTests
         // Assert
         viewModel.ShouldShowBanner.Should().Be(shouldShowBanner);
     }
-    
+
     [TestCase(1, 0, false)]
     [TestCase(2, 0, true)]
     [TestCase(3, 0, true)]
-    [TestCase(4, 0,true)]
-    [TestCase(100, 0,true)]
+    [TestCase(4, 0, true)]
+    [TestCase(100, 0, true)]
     [TestCase(0, 1, true)]
     public void HomepageViewModel_OnlyWhenUserHasOneLocalAuthority_ShouldNotShowFilters
     (

--- a/HerPortal.UnitTests/Website/Models/HomepageViewModelTests.cs
+++ b/HerPortal.UnitTests/Website/Models/HomepageViewModelTests.cs
@@ -39,6 +39,7 @@ public class HomepageViewModelTests
         {
             HasLoggedIn = hasUserLoggedIn,
             LocalAuthorities = new List<LocalAuthority>(),
+            Consortia = new List<Consortium>()
         };
         
         // Act
@@ -48,14 +49,16 @@ public class HomepageViewModelTests
         viewModel.ShouldShowBanner.Should().Be(shouldShowBanner);
     }
     
-    [TestCase(1, false)]
-    [TestCase(2, true)]
-    [TestCase(3, true)]
-    [TestCase(4, true)]
-    [TestCase(100, true)]
+    [TestCase(1, 0, false)]
+    [TestCase(2, 0, true)]
+    [TestCase(3, 0, true)]
+    [TestCase(4, 0,true)]
+    [TestCase(100, 0,true)]
+    [TestCase(0, 1, true)]
     public void HomepageViewModel_OnlyWhenUserHasOneLocalAuthority_ShouldNotShowFilters
     (
         int numberOfLas,
+        int numberOfConsortia,
         bool expected
     ) {
         // Arrange
@@ -65,6 +68,7 @@ public class HomepageViewModelTests
             LocalAuthorities = ValidLocalAuthorityGenerator
                 .GetLocalAuthoritiesWithDifferentCodes(numberOfLas)
                 .ToList(),
+            Consortia = ValidConsortiumGenerator.GetConsortiaWithDifferentCodes(numberOfConsortia).ToList()
         };
         
         // Act

--- a/HerPortal/Controllers/HomeController.cs
+++ b/HerPortal/Controllers/HomeController.cs
@@ -58,15 +58,12 @@ public class HomeController : Controller
             };
         }
 
-        var consortiumCodes = userService.GetConsortiumCodesForUser(userData);
-
         var homepageViewModel = new HomepageViewModel
         (
             userData,
             csvFilePage,
             GetPageLink,
-            GetDownloadLink,
-            consortiumCodes
+            GetDownloadLink
         );
 
         if (!userData.HasLoggedIn)

--- a/HerPortal/Models/HomepageViewModel.cs
+++ b/HerPortal/Models/HomepageViewModel.cs
@@ -61,15 +61,15 @@ public class HomepageViewModel
     public string[] PageUrls { get; }
 
     public HomepageViewModel(
-        User user, 
-        PaginatedFileData paginatedFileData, 
+        User user,
+        PaginatedFileData paginatedFileData,
         Func<int, string> pageLinkGenerator,
         Func<CsvFileData, string> downloadLinkGenerator
-        )
+    )
     {
-        var administeredCustodianCodes = user.GetAdministeredCustodianCodes();
-        var consortiumCodes = user.Consortia.Select(c => c.ConsortiumCode).ToList();
-        var checkboxLabels = administeredCustodianCodes
+        var custodianCodes = user.GetAdministeredCustodianCodes();
+        var consortiumCodes = user.GetAdministeredConsortiumCodes();
+        var checkboxLabels = custodianCodes
             .Select(custodianCode => new KeyValuePair<string, LabelViewModel>
                 (
                     custodianCode,
@@ -90,9 +90,9 @@ public class HomepageViewModel
         )));
 
         ShouldShowBanner = !user.HasLoggedIn;
-        ShouldShowFilters = administeredCustodianCodes.Count >= 2;
+        ShouldShowFilters = custodianCodes.Count >= 2;
         Codes = new List<string>();
-        Codes.AddRange(administeredCustodianCodes);
+        Codes.AddRange(custodianCodes);
         Codes.AddRange(consortiumCodes);
         LocalAuthorityCheckboxLabels = new Dictionary<string, LabelViewModel>(checkboxLabels
             .OrderBy(kvp => kvp.Value.Text)

--- a/HerPortal/Models/HomepageViewModel.cs
+++ b/HerPortal/Models/HomepageViewModel.cs
@@ -67,8 +67,8 @@ public class HomepageViewModel
         Func<CsvFileData, string> downloadLinkGenerator
     )
     {
-        var custodianCodes = user.GetAdministeredCustodianCodes();
-        var consortiumCodes = user.GetAdministeredConsortiumCodes();
+        var custodianCodes = user.GetAdministeredCustodianCodes().ToList();
+        var consortiumCodes = user.GetAdministeredConsortiumCodes().ToList();
         var checkboxLabels = custodianCodes
             .Select(custodianCode => new KeyValuePair<string, LabelViewModel>
                 (

--- a/HerPortal/Models/HomepageViewModel.cs
+++ b/HerPortal/Models/HomepageViewModel.cs
@@ -68,13 +68,13 @@ public class HomepageViewModel
         List<string> consortiumCodes
         )
     {
-        var checkboxLabels = user.LocalAuthorities
-            .Select(la => new KeyValuePair<string, LabelViewModel>
+        var checkboxLabels = user.GetAdministratedCustodianCodes()
+            .Select(custodianCode => new KeyValuePair<string, LabelViewModel>
                 (
-                    la.CustodianCode,
+                    custodianCode,
                     new LabelViewModel
                     {
-                        Text = LocalAuthorityData.LocalAuthorityNamesByCustodianCode[la.CustodianCode],
+                        Text = LocalAuthorityData.LocalAuthorityNamesByCustodianCode[custodianCode],
                     }
                 )
             )
@@ -89,9 +89,9 @@ public class HomepageViewModel
             )));
         
         ShouldShowBanner = !user.HasLoggedIn;
-        ShouldShowFilters = user.LocalAuthorities.Count >= 2;
+        ShouldShowFilters = user.GetAdministratedCustodianCodes().Count >= 2;
         Codes = new List<string>();
-        Codes.AddRange(user.LocalAuthorities.Select(la => la.CustodianCode));
+        Codes.AddRange(user.GetAdministratedCustodianCodes());
         Codes.AddRange(consortiumCodes);
         LocalAuthorityCheckboxLabels = new Dictionary<string, LabelViewModel>(checkboxLabels
             .OrderBy(kvp => kvp.Value.Text)

--- a/HerPortal/Models/HomepageViewModel.cs
+++ b/HerPortal/Models/HomepageViewModel.cs
@@ -64,34 +64,35 @@ public class HomepageViewModel
         User user, 
         PaginatedFileData paginatedFileData, 
         Func<int, string> pageLinkGenerator,
-        Func<CsvFileData, string> downloadLinkGenerator,
-        List<string> consortiumCodes
+        Func<CsvFileData, string> downloadLinkGenerator
         )
     {
-        var checkboxLabels = user.GetAdministratedCustodianCodes()
+        var administeredCustodianCodes = user.GetAdministeredCustodianCodes();
+        var consortiumCodes = user.Consortia.Select(c => c.ConsortiumCode).ToList();
+        var checkboxLabels = administeredCustodianCodes
             .Select(custodianCode => new KeyValuePair<string, LabelViewModel>
                 (
                     custodianCode,
                     new LabelViewModel
                     {
-                        Text = LocalAuthorityData.LocalAuthorityNamesByCustodianCode[custodianCode],
+                        Text = LocalAuthorityData.LocalAuthorityNamesByCustodianCode[custodianCode]
                     }
                 )
             )
             .ToList();
-        
+
         checkboxLabels.AddRange(consortiumCodes.Select(consortiumCode => new KeyValuePair<string, LabelViewModel>(
             consortiumCode,
             new LabelViewModel
             {
                 Text = $"{ConsortiumData.ConsortiumNamesByConsortiumCode[consortiumCode]} (Consortium)"
             }
-            )));
-        
+        )));
+
         ShouldShowBanner = !user.HasLoggedIn;
-        ShouldShowFilters = user.GetAdministratedCustodianCodes().Count >= 2;
+        ShouldShowFilters = administeredCustodianCodes.Count >= 2;
         Codes = new List<string>();
-        Codes.AddRange(user.GetAdministratedCustodianCodes());
+        Codes.AddRange(administeredCustodianCodes);
         Codes.AddRange(consortiumCodes);
         LocalAuthorityCheckboxLabels = new Dictionary<string, LabelViewModel>(checkboxLabels
             .OrderBy(kvp => kvp.Value.Text)


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1084)

# Description

- Added method to users which returns the combined list of all Custodian Codes for LA's they administrate, and Custodian Codes of all LA's mapped to Consortiums that the user administrates.
- Replaced many usages of a user's list of LAs to use the above method instead, where the intent was to get all LAs a user administrates.
- Included Consortia when users are being retrieved from the database.
- In DataAccessProvider, when calculating which consortium users manage from a user's list of LAs, added list of user's known consortium codes onto the calculated list.
- Updated tests to account for updated usages of Consortia.
- Updated userBuilder for tests to include a consortia field.
- Added new test helper to get x valid consortia, using the LA version as a template.

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the main HUG2 repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta)