### PR TITLE
PC-1085 Update user management scripts to onboard consortium admins

### DIFF
--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -87,10 +87,8 @@ public class AdminAction
         var lasToRemove = user.LocalAuthorities.Where(la => custodianCodes.Contains(la.CustodianCode)).ToList();
         var missingCodes = custodianCodes.Where(code => !lasToRemove.Any(la => la.CustodianCode.Equals(code))).ToList();
         if (missingCodes.Count > 0)
-        {
             throw new KeyNotFoundException(
                 $"Could not find LAs attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");
-        }
 
         dbOperation.RemoveLasFromUser(user, lasToRemove);
     }
@@ -115,10 +113,8 @@ public class AdminAction
         var missingCodes = consortiumCodes
             .Where(code => !consortiaToRemove.Any(consortium => consortium.ConsortiumCode.Equals(code))).ToList();
         if (missingCodes.Count > 0)
-        {
             throw new KeyNotFoundException(
                 $"Could not find Consortia attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");
-        }
 
         dbOperation.RemoveConsortiaFromUser(user, consortiaToRemove);
     }

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -317,7 +317,14 @@ public class AdminAction
             return;
         }
 
-        dbOperation.AddConsortiaAndRemoveLasFromUser(user, consortiaToAdd, lasToRemove);
+        if (lasToRemove.Count > 0)
+        {
+            dbOperation.AddConsortiaAndRemoveLasFromUser(user, consortiaToAdd, lasToRemove);
+        }
+        else
+        {
+            dbOperation.AddConsortiaToUser(user, consortiaToAdd);
+        }
     }
 
     private (User? user, UserStatus userStatus) CheckUserStatus(string userEmailAddress)

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -260,7 +260,7 @@ public class AdminAction
         dbOperation.AddLasToUser(user, lasToAdd);
     }
 
-    public void RemoveLas(User? user, IReadOnlyCollection<string>? custodianCodes)
+    public void RemoveLas(User? user, IReadOnlyCollection<string> custodianCodes)
     {
         if (user == null)
         {
@@ -268,7 +268,7 @@ public class AdminAction
             return;
         }
 
-        if (custodianCodes == null || custodianCodes.Count < 1)
+        if (custodianCodes.Count == 0)
         {
             outputProvider.Output("Please specify custodian codes to remove from user");
             return;
@@ -399,7 +399,7 @@ public class AdminAction
         }
     }
 
-    public void RemoveConsortia(User? user, IReadOnlyCollection<string>? consortiumCodes)
+    public void RemoveConsortia(User? user, IReadOnlyCollection<string> consortiumCodes)
     {
         if (user == null)
         {
@@ -407,7 +407,7 @@ public class AdminAction
             return;
         }
 
-        if (consortiumCodes == null || consortiumCodes.Count < 1)
+        if (consortiumCodes.Count == 0)
         {
             outputProvider.Output("Please specify consortium codes to remove from user");
             return;

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -327,14 +327,8 @@ public class AdminAction
         return (user, userStatus);
     }
 
-    public void CreateOrUpdateUserWithLas(string? userEmailAddress, IReadOnlyCollection<string> custodianCodes)
+    public void CreateOrUpdateUserWithLas(string userEmailAddress, IReadOnlyCollection<string> custodianCodes)
     {
-        if (userEmailAddress == null)
-        {
-            outputProvider.Output("Please specify user E-mail address to create or update");
-            return;
-        }
-
         var (user, userStatus) = CheckUserStatus(userEmailAddress);
 
         var confirmation = ConfirmAddCustodianCodes(userEmailAddress, custodianCodes, user);
@@ -351,14 +345,8 @@ public class AdminAction
             }
     }
 
-    public void CreateOrUpdateUserWithConsortia(string? userEmailAddress, IReadOnlyCollection<string> consortiumCodes)
+    public void CreateOrUpdateUserWithConsortia(string userEmailAddress, IReadOnlyCollection<string> consortiumCodes)
     {
-        if (userEmailAddress == null)
-        {
-            outputProvider.Output("Please specify user E-mail address to create or update");
-            return;
-        }
-
         var (user, userStatus) = CheckUserStatus(userEmailAddress);
 
         var confirmation = ConfirmAddConsortiumCodes(userEmailAddress, consortiumCodes, user);

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -87,7 +87,7 @@ public class AdminAction
         var lasToRemove = user.LocalAuthorities.Where(la => custodianCodes.Contains(la.CustodianCode)).ToList();
         var missingCodes = custodianCodes.Where(code => !lasToRemove.Any(la => la.CustodianCode.Equals(code))).ToList();
         if (missingCodes.Count > 0)
-            throw new KeyNotFoundException(
+            throw new CommandException(
                 $"Could not find LAs attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");
 
         dbOperation.RemoveLasFromUser(user, lasToRemove);
@@ -113,7 +113,7 @@ public class AdminAction
         var missingCodes = consortiumCodes
             .Where(code => !consortiaToRemove.Any(consortium => consortium.ConsortiumCode.Equals(code))).ToList();
         if (missingCodes.Count > 0)
-            throw new KeyNotFoundException(
+            throw new CommandException(
                 $"Could not find Consortia attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");
 
         dbOperation.RemoveConsortiaFromUser(user, consortiaToRemove);

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -85,8 +85,7 @@ public partial class AdminAction
                 .Contains(code))
             .ToList();
         if (missingCodes.Count > 0)
-            throw new CommandException(
-                $"Could not find LAs attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");
+            throw new CouldNotFindAuthorityException("Custodian Codes are not associated with this user.", missingCodes);
 
         dbOperation.RemoveLasFromUser(user, lasToRemove);
     }
@@ -114,8 +113,7 @@ public partial class AdminAction
                 .Contains(code)
             ).ToList();
         if (missingCodes.Count > 0)
-            throw new CommandException(
-                $"Could not find Consortia attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");
+            throw new CouldNotFindAuthorityException("Consortium Codes are not associated with this user.", missingCodes);
 
         dbOperation.RemoveConsortiaFromUser(user, consortiaToRemove);
     }

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -83,10 +83,11 @@ public class AdminAction
         return userOrNull == null ? UserStatus.New : UserStatus.Active;
     }
 
-    private void TryCreateUser(string userEmailAddress, string[]? custodianCodes)
+    private void TryCreateUser(string userEmailAddress, string[]? custodianCodes, string[]? consortiumCodes)
     {
         var lasToAdd = dbOperation.GetLas(custodianCodes ?? Array.Empty<string>());
-        dbOperation.CreateUserOrLogError(userEmailAddress, lasToAdd);
+        var consortiaToAdd = dbOperation.GetConsortia(consortiumCodes ?? Array.Empty<string>());
+        dbOperation.CreateUserOrLogError(userEmailAddress, lasToAdd, consortiaToAdd);
     }
 
     public void TryRemoveUser(User? user)
@@ -155,7 +156,7 @@ public class AdminAction
         dbOperation.RemoveLasFromUser(user, lasToRemove);
     }
 
-    public void CreateOrUpdateUser(string? userEmailAddress, string[] custodianCodes)
+    public void CreateOrUpdateUserWithLas(string? userEmailAddress, string[] custodianCodes)
     {
         if (userEmailAddress == null)
         {
@@ -185,7 +186,7 @@ public class AdminAction
             }
             else if (userStatus.Equals(UserStatus.New))
             {
-                TryCreateUser(userEmailAddress, custodianCodes);
+                TryCreateUser(userEmailAddress, custodianCodes, null);
             }
         }
     }

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -2,14 +2,8 @@ using HerPortal.BusinessLogic.Models;
 
 namespace HerPortal.ManagementShell;
 
-public class AdminAction
+public partial class AdminAction
 {
-    public enum UserStatus
-    {
-        New,
-        Active
-    }
-
     private readonly Dictionary<string, List<string>> consortiumCodeToCustodianCodesDict =
         ConsortiumData.ConsortiumCustodianCodesIdsByConsortiumCode;
 
@@ -52,9 +46,9 @@ public class AdminAction
             .ToList();
     }
 
-    public UserStatus GetUserStatus(User? userOrNull)
+    public UserAccountStatus GetUserStatus(User? userOrNull)
     {
-        return userOrNull == null ? UserStatus.New : UserStatus.Active;
+        return userOrNull == null ? UserAccountStatus.New : UserAccountStatus.Active;
     }
 
     public void CreateUser(string userEmailAddress, IReadOnlyCollection<string>? custodianCodes,
@@ -85,7 +79,10 @@ public class AdminAction
     public void RemoveLas(User user, IReadOnlyCollection<string> custodianCodes)
     {
         var lasToRemove = user.LocalAuthorities.Where(la => custodianCodes.Contains(la.CustodianCode)).ToList();
-        var missingCodes = custodianCodes.Where(code => !lasToRemove.Any(la => la.CustodianCode.Equals(code))).ToList();
+        var missingCodes = custodianCodes.Where(code => 
+            !lasToRemove
+                .Any(la => la.CustodianCode.Equals(code)))
+            .ToList();
         if (missingCodes.Count > 0)
             throw new CommandException(
                 $"Could not find LAs attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -10,31 +10,17 @@ public class AdminAction
         Active
     }
 
-    private readonly Dictionary<string, string> consortiumCodeToConsortiumNameDict =
-        ConsortiumData.ConsortiumNamesByConsortiumCode;
-
     private readonly Dictionary<string, List<string>> consortiumCodeToCustodianCodesDict =
         ConsortiumData.ConsortiumCustodianCodesIdsByConsortiumCode;
 
     private readonly Dictionary<string, string> custodianCodeToConsortiumCodeDict =
         LocalAuthorityData.LocalAuthorityConsortiumCodeByCustodianCode;
 
-    private readonly Dictionary<string, string> custodianCodeToConsortiumNameDict =
-        LocalAuthorityData.LocalAuthorityConsortiumCodeByCustodianCode
-            .ToDictionary(
-                kvp => kvp.Key,
-                kvp => ConsortiumData.ConsortiumNamesByConsortiumCode[kvp.Value]);
-
-    private readonly Dictionary<string, string> custodianCodeToLaNameDict =
-        LocalAuthorityData.LocalAuthorityNamesByCustodianCode;
-
     private readonly IDatabaseOperation dbOperation;
-    private readonly IOutputProvider outputProvider;
 
-    public AdminAction(IDatabaseOperation dbOperation, IOutputProvider outputProvider)
+    public AdminAction(IDatabaseOperation dbOperation)
     {
         this.dbOperation = dbOperation;
-        this.outputProvider = outputProvider;
     }
 
     public User? GetUser(string emailAddress)
@@ -49,53 +35,7 @@ public class AdminAction
             ));
     }
 
-    private void PrintCodes(IReadOnlyCollection<string> codes, Func<string, string> codeToName)
-    {
-        if (codes.Count < 1) outputProvider.Output("(None)");
-
-        foreach (var code in codes)
-        {
-            var name = codeToName(code);
-            outputProvider.Output($"{code}: {name}");
-        }
-    }
-
-    private bool ConfirmAddCustodianCodes(string userEmailAddress, IReadOnlyCollection<string> custodianCodes, User? user)
-    {
-        return ConfirmChangesToDatabase(userEmailAddress, () =>
-        {
-            if (user != null)
-            {
-                // flag the need to not add LAs that are in consortia the user owns
-                var custodianCodeInOwnedConsortiumGrouping = custodianCodes.ToLookup(custodianCode =>
-                    CustodianCodeIsInOwnedConsortium(user, custodianCode));
-                var custodianCodesNotInOwnedConsortium = custodianCodeInOwnedConsortiumGrouping[false].ToList();
-                var custodianCodesInOwnedConsortium = custodianCodeInOwnedConsortiumGrouping[true].ToList();
-
-                outputProvider.Output("Add the following Local Authorities:");
-                PrintCodes(custodianCodesNotInOwnedConsortium, code => custodianCodeToLaNameDict[code]);
-                outputProvider.Output("Ignore the following Local Authorities already in owned Consortia:");
-                PrintCodes(custodianCodesInOwnedConsortium, code =>
-                    $"{custodianCodeToLaNameDict[code]} ({custodianCodeToConsortiumNameDict[code]})");
-            }
-            else
-            {
-                outputProvider.Output("Add the following Local Authorities:");
-                PrintCodes(custodianCodes, code => custodianCodeToLaNameDict[code]);
-            }
-        });
-    }
-
-    private bool ConfirmRemoveCustodianCodes(string userEmailAddress, IReadOnlyCollection<string> custodianCodes)
-    {
-        return ConfirmChangesToDatabase(userEmailAddress, () =>
-        {
-            outputProvider.Output("Remove the following Local Authorities:");
-            PrintCodes(custodianCodes, code => custodianCodeToLaNameDict[code]);
-        });
-    }
-
-    private bool CustodianCodeIsInOwnedConsortium(User user, string custodianCode)
+    public bool CustodianCodeIsInOwnedConsortium(User user, string custodianCode)
     {
         var custodianCodesOfConsortia = user.Consortia
             .SelectMany(consortium =>
@@ -103,62 +43,7 @@ public class AdminAction
         return custodianCodesOfConsortia.Contains(custodianCode);
     }
 
-    private bool ConfirmAddConsortiumCodes(string? userEmailAddress, IReadOnlyCollection<string> consortiumCodes,
-        User? user)
-    {
-        return ConfirmChangesToDatabase(userEmailAddress, () =>
-        {
-            if (user != null)
-            {
-                outputProvider.Output("Add the following Consortia:");
-                PrintCodes(consortiumCodes, code => consortiumCodeToConsortiumNameDict[code]);
-
-                // flag the need to remove access for any LAs in the new consortia
-                var ownedCustodianCodesInConsortia = GetOwnedCustodianCodesInConsortia(user, consortiumCodes);
-
-                outputProvider.Output("Remove the following Local Authorities in these Consortia:");
-                PrintCodes(ownedCustodianCodesInConsortia, code =>
-                    $"{custodianCodeToLaNameDict[code]} ({custodianCodeToConsortiumNameDict[code]})");
-            }
-            else
-            {
-                outputProvider.Output("Add the following Consortia:");
-                PrintCodes(consortiumCodes, code => consortiumCodeToConsortiumNameDict[code]);
-            }
-        });
-    }
-
-    private bool ConfirmRemoveConsortiumCodes(string? userEmailAddress, IReadOnlyCollection<string> consortiumCodes)
-    {
-        return ConfirmChangesToDatabase(userEmailAddress, () =>
-        {
-            outputProvider.Output("Remove the following Consortia:");
-            PrintCodes(consortiumCodes, code => consortiumCodeToConsortiumNameDict[code]);
-        });
-    }
-
-    private bool ConfirmChangesToDatabase(string? userEmailAddress, Action printAction)
-    {
-        outputProvider.Output(
-            $"You are changing permissions for user {userEmailAddress}:");
-
-        try
-        {
-            printAction();
-        }
-        catch (Exception e)
-        {
-            outputProvider.Output($"{e.Message} Process terminated");
-            return false;
-        }
-
-        var hasUserConfirmed = outputProvider.Confirm("Please confirm (y/n)");
-        if (!hasUserConfirmed) outputProvider.Output("Process cancelled, no changes were made to the database");
-
-        return hasUserConfirmed;
-    }
-
-    private List<string> GetOwnedCustodianCodesInConsortia(User user, IEnumerable<string> consortiumCodes)
+    public List<string> GetOwnedCustodianCodesInConsortia(User user, IEnumerable<string> consortiumCodes)
     {
         return user.LocalAuthorities
             .Where(localAuthority =>
@@ -167,228 +52,72 @@ public class AdminAction
             .ToList();
     }
 
-    private void DisplayUserStatus(Enum status)
-    {
-        switch (status)
-        {
-            case UserStatus.New:
-                outputProvider.Output("User not found in database. A new user will be created");
-                break;
-            case UserStatus.Active:
-                outputProvider.Output("User found in database. LAs will be added to their account");
-                break;
-        }
-    }
-
-    private UserStatus GetUserStatus(User? userOrNull)
+    public UserStatus GetUserStatus(User? userOrNull)
     {
         return userOrNull == null ? UserStatus.New : UserStatus.Active;
     }
 
-    private void TryCreateUser(string userEmailAddress, IReadOnlyCollection<string>? custodianCodes,
+    public void CreateUser(string userEmailAddress, IReadOnlyCollection<string>? custodianCodes,
         IReadOnlyCollection<string>? consortiumCodes)
     {
-        try
-        {
-            var lasToAdd = dbOperation.GetLas(custodianCodes ?? Array.Empty<string>());
-            var consortiaToAdd = dbOperation.GetConsortia(consortiumCodes ?? Array.Empty<string>());
+        var lasToAdd = dbOperation.GetLas(custodianCodes ?? Array.Empty<string>());
+        var consortiaToAdd = dbOperation.GetConsortia(consortiumCodes ?? Array.Empty<string>());
 
-            dbOperation.CreateUserOrLogError(userEmailAddress, lasToAdd, consortiaToAdd);
-        }
-        catch (KeyNotFoundException keyNotFoundException)
-        {
-            outputProvider.Output($"Could not create user: {keyNotFoundException.Message}");
-        }
+        dbOperation.CreateUserOrLogError(userEmailAddress, lasToAdd, consortiaToAdd);
     }
 
-    public void TryRemoveUser(User? user)
+    public void RemoveUser(User user)
     {
-        if (user == null)
-        {
-            outputProvider.Output("User not found");
-            return;
-        }
-
-        var deletionConfirmation = outputProvider.Confirm(
-            $"Attention! This will delete user {user.EmailAddress} and all associated rows from the database. Are you sure you want to commit this transaction? (y/n)");
-        if (!deletionConfirmation) return;
-
         dbOperation.RemoveUserOrLogError(user);
     }
 
-    private void AddLas(User? user, IReadOnlyCollection<string>? custodianCodes)
+    public void AddLas(User user, IEnumerable<string> custodianCodes)
     {
-        if (user == null)
-        {
-            outputProvider.Output("User not found");
-            return;
-        }
+        var filteredCustodianCodes = custodianCodes
+            .Where(custodianCode => !CustodianCodeIsInOwnedConsortium(user, custodianCode))
+            .ToList();
 
-        if (custodianCodes == null || custodianCodes.Count < 1)
-        {
-            outputProvider.Output("Please specify custodian codes to add to user");
-            return;
-        }
+        var lasToAdd = dbOperation.GetLas(filteredCustodianCodes);
 
-        try
-        {
-            var filteredCustodianCodes = custodianCodes
-                .Where(custodianCode => !CustodianCodeIsInOwnedConsortium(user, custodianCode))
-                .ToList();
-
-            var lasToAdd = dbOperation.GetLas(filteredCustodianCodes);
-
-            dbOperation.AddLasToUser(user, lasToAdd);
-        }
-        catch (KeyNotFoundException keyNotFoundException)
-        {
-            outputProvider.Output($"Could not add LAs to user: {keyNotFoundException.Message}");
-        }
+        dbOperation.AddLasToUser(user, lasToAdd);
     }
 
-    public void RemoveLas(User? user, IReadOnlyCollection<string> custodianCodes)
+    public void RemoveLas(User user, IReadOnlyCollection<string> custodianCodes)
     {
-        if (user == null)
-        {
-            outputProvider.Output("User not found");
-            return;
-        }
-
-        if (custodianCodes.Count == 0)
-        {
-            outputProvider.Output("Please specify custodian codes to remove from user");
-            return;
-        }
-
-        var userConfirmation = ConfirmRemoveCustodianCodes(user.EmailAddress, custodianCodes);
-        if (!userConfirmation) return;
-
         var lasToRemove = user.LocalAuthorities.Where(la => custodianCodes.Contains(la.CustodianCode)).ToList();
         var missingCodes = custodianCodes.Where(code => !lasToRemove.Any(la => la.CustodianCode.Equals(code))).ToList();
         if (missingCodes.Count > 0)
         {
-            outputProvider.Output(
+            throw new KeyNotFoundException(
                 $"Could not find LAs attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");
-            return;
         }
 
         dbOperation.RemoveLasFromUser(user, lasToRemove);
     }
 
-    private void AddConsortia(User? user, IReadOnlyCollection<string>? consortiumCodes)
+    public void AddConsortia(User user, IReadOnlyCollection<string> consortiumCodes)
     {
-        if (user == null)
-        {
-            outputProvider.Output("User not found");
-            return;
-        }
+        var consortiaToAdd = dbOperation.GetConsortia(consortiumCodes);
 
-        if (consortiumCodes == null || consortiumCodes.Count < 1)
-        {
-            outputProvider.Output("Please specify consortium codes to add to user");
-            return;
-        }
+        var ownedCustodianCodesInConsortia = GetOwnedCustodianCodesInConsortia(user, consortiumCodes);
+        var lasToRemove = dbOperation.GetLas(ownedCustodianCodesInConsortia);
 
-        try
-        {
-            var consortiaToAdd = dbOperation.GetConsortia(consortiumCodes);
-
-            var ownedCustodianCodesInConsortia = GetOwnedCustodianCodesInConsortia(user, consortiumCodes);
-            var lasToRemove = dbOperation.GetLas(ownedCustodianCodesInConsortia);
-
-            if (lasToRemove.Count > 0)
-                dbOperation.AddConsortiaAndRemoveLasFromUser(user, consortiaToAdd, lasToRemove);
-            else
-                dbOperation.AddConsortiaToUser(user, consortiaToAdd);
-        }
-        catch (KeyNotFoundException keyNotFoundException)
-        {
-            outputProvider.Output($"Could not add Consortia to user: {keyNotFoundException.Message}");
-        }
+        if (lasToRemove.Count > 0)
+            dbOperation.AddConsortiaAndRemoveLasFromUser(user, consortiaToAdd, lasToRemove);
+        else
+            dbOperation.AddConsortiaToUser(user, consortiaToAdd);
     }
 
-    private (User? user, UserStatus userStatus) CheckUserStatus(string userEmailAddress)
+    public void RemoveConsortia(User user, IReadOnlyCollection<string> consortiumCodes)
     {
-        var user = GetUser(userEmailAddress);
-        var userStatus = GetUserStatus(user);
-        DisplayUserStatus(userStatus);
-        outputProvider.Output("");
-
-        outputProvider.Output("!!! ATTENTION! READ CAREFULLY OR RISK A DATA BREACH !!!");
-        outputProvider.Output("");
-        outputProvider.Output(
-            "You are about to grant a user permission to read PERSONALLY IDENTIFIABLE INFORMATION submitted to LAs.");
-        outputProvider.Output(
-            "Take a moment to double check the following list and only continue if you are certain this user should have access to these LAs.");
-        outputProvider.Output(
-            "NB: in particular, you should only do this for LAs that have signed their DSA contracts!");
-        outputProvider.Output("");
-
-        return (user, userStatus);
-    }
-
-    public void CreateOrUpdateUserWithLas(string userEmailAddress, IReadOnlyCollection<string> custodianCodes)
-    {
-        var (user, userStatus) = CheckUserStatus(userEmailAddress);
-
-        var confirmation = ConfirmAddCustodianCodes(userEmailAddress, custodianCodes, user);
-
-        if (confirmation)
-            switch (userStatus)
-            {
-                case UserStatus.Active:
-                    AddLas(user, custodianCodes);
-                    break;
-                case UserStatus.New:
-                    TryCreateUser(userEmailAddress, custodianCodes, null);
-                    break;
-            }
-    }
-
-    public void CreateOrUpdateUserWithConsortia(string userEmailAddress, IReadOnlyCollection<string> consortiumCodes)
-    {
-        var (user, userStatus) = CheckUserStatus(userEmailAddress);
-
-        var confirmation = ConfirmAddConsortiumCodes(userEmailAddress, consortiumCodes, user);
-
-        if (confirmation)
-            switch (userStatus)
-            {
-                case UserStatus.Active:
-                    AddConsortia(user, consortiumCodes);
-                    break;
-                case UserStatus.New:
-                    TryCreateUser(userEmailAddress, null, consortiumCodes);
-                    break;
-            }
-    }
-
-    public void RemoveConsortia(User? user, IReadOnlyCollection<string> consortiumCodes)
-    {
-        if (user == null)
-        {
-            outputProvider.Output("User not found");
-            return;
-        }
-
-        if (consortiumCodes.Count == 0)
-        {
-            outputProvider.Output("Please specify consortium codes to remove from user");
-            return;
-        }
-
-        var userConfirmation = ConfirmRemoveConsortiumCodes(user.EmailAddress, consortiumCodes);
-        if (!userConfirmation) return;
-
         var consortiaToRemove = user.Consortia.Where(consortium => consortiumCodes.Contains(consortium.ConsortiumCode))
             .ToList();
         var missingCodes = consortiumCodes
             .Where(code => !consortiaToRemove.Any(consortium => consortium.ConsortiumCode.Equals(code))).ToList();
         if (missingCodes.Count > 0)
         {
-            outputProvider.Output(
+            throw new KeyNotFoundException(
                 $"Could not find Consortia attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");
-            return;
         }
 
         dbOperation.RemoveConsortiaFromUser(user, consortiaToRemove);

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -49,7 +49,7 @@ public class AdminAction
         }
     }
 
-    private bool ConfirmCustodianCodes(string userEmailAddress, string[] custodianCodes, User? user)
+    private bool ConfirmCustodianCodes(string userEmailAddress, IReadOnlyCollection<string> custodianCodes, User? user)
     {
         outputProvider.Output(
             $"You are changing permissions for user {userEmailAddress} for the following Local Authorities:");
@@ -98,7 +98,7 @@ public class AdminAction
         return custodianCodesOfConsortia.Contains(custodianCode);
     }
 
-    private bool ConfirmConsortiumCodes(string? userEmailAddress, string[] consortiumCodes, User? user)
+    private bool ConfirmConsortiumCodes(string? userEmailAddress, IReadOnlyCollection<string> consortiumCodes, User? user)
     {
         outputProvider.Output(
             $"You are changing permissions for user {userEmailAddress} for the following Consortia:");
@@ -137,7 +137,7 @@ public class AdminAction
         return hasUserConfirmed;
     }
 
-    private List<string> GetOwnedCustodianCodesInConsortia(User user, string[] consortiumCodes)
+    private List<string> GetOwnedCustodianCodesInConsortia(User user, IEnumerable<string> consortiumCodes)
     {
         return user.LocalAuthorities
             .Where(localAuthority =>
@@ -164,7 +164,7 @@ public class AdminAction
         return userOrNull == null ? UserStatus.New : UserStatus.Active;
     }
 
-    private void TryCreateUser(string userEmailAddress, string[]? custodianCodes, string[]? consortiumCodes)
+    private void TryCreateUser(string userEmailAddress, IEnumerable<string>? custodianCodes, IEnumerable<string>? consortiumCodes)
     {
         var lasToAdd = dbOperation.GetLas(custodianCodes ?? Array.Empty<string>());
         var consortiaToAdd = dbOperation.GetConsortia(consortiumCodes ?? Array.Empty<string>());
@@ -188,7 +188,7 @@ public class AdminAction
 
         dbOperation.RemoveUserOrLogError(user);
     }
-    private void AddLas(User? user, string[]? custodianCodes)
+    private void AddLas(User? user, IReadOnlyCollection<string>? custodianCodes)
     {
         if (user == null)
         {
@@ -196,7 +196,7 @@ public class AdminAction
             return;
         }
 
-        if (custodianCodes == null || custodianCodes.Length < 1)
+        if (custodianCodes == null || custodianCodes.Count < 1)
         {
             outputProvider.Output("Please specify custodian codes to add to user");
             return;
@@ -209,7 +209,7 @@ public class AdminAction
         dbOperation.AddLasToUser(user, lasToAdd);
     }
 
-    public void RemoveLas(User? user, string[]? custodianCodes)
+    public void RemoveLas(User? user, IReadOnlyCollection<string>? custodianCodes)
     {
         if (user == null)
         {
@@ -217,7 +217,7 @@ public class AdminAction
             return;
         }
 
-        if (custodianCodes == null || custodianCodes.Length < 1)
+        if (custodianCodes == null || custodianCodes.Count < 1)
         {
             outputProvider.Output("Please specify custodian codes to remove from user");
             return;
@@ -240,7 +240,7 @@ public class AdminAction
         dbOperation.RemoveLasFromUser(user, lasToRemove);
     }
     
-    private void AddConsortia(User? user, string[]? consortiumCodes)
+    private void AddConsortia(User? user, IReadOnlyCollection<string>? consortiumCodes)
     {
         if (user == null)
         {
@@ -248,7 +248,7 @@ public class AdminAction
             return;
         }
 
-        if (consortiumCodes == null || consortiumCodes.Length < 1)
+        if (consortiumCodes == null || consortiumCodes.Count < 1)
         {
             outputProvider.Output("Please specify consortium codes to add to user");
             return;
@@ -279,7 +279,7 @@ public class AdminAction
         return (user, userStatus);
     }
 
-    public void CreateOrUpdateUserWithLas(string? userEmailAddress, string[] custodianCodes)
+    public void CreateOrUpdateUserWithLas(string? userEmailAddress, IReadOnlyCollection<string> custodianCodes)
     {
         if (userEmailAddress == null)
         {
@@ -304,7 +304,7 @@ public class AdminAction
         }
     }
 
-    public void CreateOrUpdateUserWithConsortia(string? userEmailAddress, string[] consortiumCodes)
+    public void CreateOrUpdateUserWithConsortia(string? userEmailAddress, IReadOnlyCollection<string> consortiumCodes)
     {
         if (userEmailAddress == null)
         {

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -81,7 +81,8 @@ public partial class AdminAction
         var lasToRemove = user.LocalAuthorities.Where(la => custodianCodes.Contains(la.CustodianCode)).ToList();
         var missingCodes = custodianCodes.Where(code => 
             !lasToRemove
-                .Any(la => la.CustodianCode.Equals(code)))
+                .Select(la => la.CustodianCode)
+                .Contains(code))
             .ToList();
         if (missingCodes.Count > 0)
             throw new CommandException(
@@ -108,7 +109,10 @@ public partial class AdminAction
         var consortiaToRemove = user.Consortia.Where(consortium => consortiumCodes.Contains(consortium.ConsortiumCode))
             .ToList();
         var missingCodes = consortiumCodes
-            .Where(code => !consortiaToRemove.Any(consortium => consortium.ConsortiumCode.Equals(code))).ToList();
+            .Where(code => !consortiaToRemove
+                .Select(consortium => consortium.ConsortiumCode)
+                .Contains(code)
+            ).ToList();
         if (missingCodes.Count > 0)
             throw new CommandException(
                 $"Could not find Consortia attached to {user.EmailAddress} for the following codes: {string.Join(", ", missingCodes)}. Please check your inputs and try again.");

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -45,7 +45,10 @@ public class AdminAction
 
     private void PrintCodes(IReadOnlyCollection<string> codes, IReadOnlyDictionary<string, string> codeToNameDict)
     {
-        if (codes.Count < 1) outputProvider.Output("(None)");
+        if (codes.Count < 1)
+        {
+            outputProvider.Output("(None)");
+        }
 
         foreach (var code in codes)
         {
@@ -93,7 +96,10 @@ public class AdminAction
         }
 
         var hasUserConfirmed = outputProvider.Confirm("Please confirm (y/n)");
-        if (!hasUserConfirmed) outputProvider.Output("Process cancelled, no changes were made to the database");
+        if (!hasUserConfirmed)
+        {
+            outputProvider.Output("Process cancelled, no changes were made to the database");
+        }
 
         return hasUserConfirmed;
     }
@@ -143,7 +149,10 @@ public class AdminAction
         }
 
         var hasUserConfirmed = outputProvider.Confirm("Please confirm (y/n)");
-        if (!hasUserConfirmed) outputProvider.Output("Process cancelled, no changes were made to the database");
+        if (!hasUserConfirmed)
+        {
+            outputProvider.Output("Process cancelled, no changes were made to the database");
+        }
 
         return hasUserConfirmed;
     }
@@ -206,7 +215,10 @@ public class AdminAction
 
         var deletionConfirmation = outputProvider.Confirm(
             $"Attention! This will delete user {user.EmailAddress} and all associated rows from the database. Are you sure you want to commit this transaction? (y/n)");
-        if (!deletionConfirmation) return;
+        if (!deletionConfirmation)
+        {
+            return;
+        }
 
         dbOperation.RemoveUserOrLogError(user);
     }
@@ -255,7 +267,10 @@ public class AdminAction
         }
 
         var userConfirmation = ConfirmCustodianCodes(user.EmailAddress, custodianCodes, user, true);
-        if (!userConfirmation) return;
+        if (!userConfirmation)
+        {
+            return;
+        }
 
         var lasToRemove = user.LocalAuthorities.Where(la => custodianCodes.Contains(la.CustodianCode)).ToList();
         var missingCodes = custodianCodes.Where(code => !lasToRemove.Any(la => la.CustodianCode.Equals(code))).ToList();
@@ -330,6 +345,7 @@ public class AdminAction
         var confirmation = ConfirmCustodianCodes(userEmailAddress, custodianCodes, user, false);
 
         if (confirmation)
+        {
             switch (userStatus)
             {
                 case UserStatus.Active:
@@ -339,6 +355,7 @@ public class AdminAction
                     TryCreateUser(userEmailAddress, custodianCodes, null);
                     break;
             }
+        }
     }
 
     public void CreateOrUpdateUserWithConsortia(string? userEmailAddress, IReadOnlyCollection<string> consortiumCodes)
@@ -354,6 +371,7 @@ public class AdminAction
         var confirmation = ConfirmConsortiumCodes(userEmailAddress, consortiumCodes, user, false);
 
         if (confirmation)
+        {
             switch (userStatus)
             {
                 case UserStatus.Active:
@@ -363,6 +381,7 @@ public class AdminAction
                     TryCreateUser(userEmailAddress, null, consortiumCodes);
                     break;
             }
+        }
     }
 
     public void RemoveConsortia(User? user, IReadOnlyCollection<string>? consortiumCodes)
@@ -380,7 +399,10 @@ public class AdminAction
         }
 
         var userConfirmation = ConfirmConsortiumCodes(user.EmailAddress, consortiumCodes, user, true);
-        if (!userConfirmation) return;
+        if (!userConfirmation)
+        {
+            return;
+        }
 
         var consortiaToRemove = user.Consortia.Where(consortium => consortiumCodes.Contains(consortium.ConsortiumCode))
             .ToList();

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -51,10 +51,7 @@ public class AdminAction
 
     private void PrintCodes(IReadOnlyCollection<string> codes, Func<string, string> codeToName)
     {
-        if (codes.Count < 1)
-        {
-            outputProvider.Output("(None)");
-        }
+        if (codes.Count < 1) outputProvider.Output("(None)");
 
         foreach (var code in codes)
         {
@@ -103,10 +100,7 @@ public class AdminAction
         }
 
         var hasUserConfirmed = outputProvider.Confirm("Please confirm (y/n)");
-        if (!hasUserConfirmed)
-        {
-            outputProvider.Output("Process cancelled, no changes were made to the database");
-        }
+        if (!hasUserConfirmed) outputProvider.Output("Process cancelled, no changes were made to the database");
 
         return hasUserConfirmed;
     }
@@ -157,10 +151,7 @@ public class AdminAction
         }
 
         var hasUserConfirmed = outputProvider.Confirm("Please confirm (y/n)");
-        if (!hasUserConfirmed)
-        {
-            outputProvider.Output("Process cancelled, no changes were made to the database");
-        }
+        if (!hasUserConfirmed) outputProvider.Output("Process cancelled, no changes were made to the database");
 
         return hasUserConfirmed;
     }
@@ -199,7 +190,7 @@ public class AdminAction
         {
             var lasToAdd = dbOperation.GetLas(custodianCodes ?? Array.Empty<string>());
             var consortiaToAdd = dbOperation.GetConsortia(consortiumCodes ?? Array.Empty<string>());
-            
+
             dbOperation.CreateUserOrLogError(userEmailAddress, lasToAdd, consortiaToAdd);
         }
         catch (KeyNotFoundException keyNotFoundException)
@@ -218,10 +209,7 @@ public class AdminAction
 
         var deletionConfirmation = outputProvider.Confirm(
             $"Attention! This will delete user {user.EmailAddress} and all associated rows from the database. Are you sure you want to commit this transaction? (y/n)");
-        if (!deletionConfirmation)
-        {
-            return;
-        }
+        if (!deletionConfirmation) return;
 
         dbOperation.RemoveUserOrLogError(user);
     }
@@ -271,10 +259,7 @@ public class AdminAction
         }
 
         var userConfirmation = ConfirmCustodianCodes(user.EmailAddress, custodianCodes, user, true);
-        if (!userConfirmation)
-        {
-            return;
-        }
+        if (!userConfirmation) return;
 
         var lasToRemove = user.LocalAuthorities.Where(la => custodianCodes.Contains(la.CustodianCode)).ToList();
         var missingCodes = custodianCodes.Where(code => !lasToRemove.Any(la => la.CustodianCode.Equals(code))).ToList();
@@ -310,13 +295,9 @@ public class AdminAction
             var lasToRemove = dbOperation.GetLas(ownedCustodianCodesInConsortia);
 
             if (lasToRemove.Count > 0)
-            {
                 dbOperation.AddConsortiaAndRemoveLasFromUser(user, consortiaToAdd, lasToRemove);
-            }
             else
-            {
                 dbOperation.AddConsortiaToUser(user, consortiaToAdd);
-            }
         }
         catch (KeyNotFoundException keyNotFoundException)
         {
@@ -357,7 +338,6 @@ public class AdminAction
         var confirmation = ConfirmCustodianCodes(userEmailAddress, custodianCodes, user, false);
 
         if (confirmation)
-        {
             switch (userStatus)
             {
                 case UserStatus.Active:
@@ -367,7 +347,6 @@ public class AdminAction
                     TryCreateUser(userEmailAddress, custodianCodes, null);
                     break;
             }
-        }
     }
 
     public void CreateOrUpdateUserWithConsortia(string? userEmailAddress, IReadOnlyCollection<string> consortiumCodes)
@@ -383,7 +362,6 @@ public class AdminAction
         var confirmation = ConfirmConsortiumCodes(userEmailAddress, consortiumCodes, user, false);
 
         if (confirmation)
-        {
             switch (userStatus)
             {
                 case UserStatus.Active:
@@ -393,7 +371,6 @@ public class AdminAction
                     TryCreateUser(userEmailAddress, null, consortiumCodes);
                     break;
             }
-        }
     }
 
     public void RemoveConsortia(User? user, IReadOnlyCollection<string> consortiumCodes)
@@ -411,10 +388,7 @@ public class AdminAction
         }
 
         var userConfirmation = ConfirmConsortiumCodes(user.EmailAddress, consortiumCodes, user, true);
-        if (!userConfirmation)
-        {
-            return;
-        }
+        if (!userConfirmation) return;
 
         var consortiaToRemove = user.Consortia.Where(consortium => consortiumCodes.Contains(consortium.ConsortiumCode))
             .ToList();

--- a/HerPortal.ManagementShell/CommandException.cs
+++ b/HerPortal.ManagementShell/CommandException.cs
@@ -1,0 +1,8 @@
+﻿namespace HerPortal.ManagementShell;
+
+public class CommandException : Exception
+{
+    public CommandException(string message) : base(message)
+    {
+    }
+}

--- a/HerPortal.ManagementShell/CommandException.cs
+++ b/HerPortal.ManagementShell/CommandException.cs
@@ -1,8 +1,0 @@
-﻿namespace HerPortal.ManagementShell;
-
-public class CommandException : Exception
-{
-    public CommandException(string message) : base(message)
-    {
-    }
-}

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -4,6 +4,8 @@ namespace HerPortal.ManagementShell;
 
 public class CommandHandler
 {
+    private readonly AdminAction adminAction;
+
     private readonly Dictionary<string, string> consortiumCodeToConsortiumNameDict =
         ConsortiumData.ConsortiumNamesByConsortiumCode;
 
@@ -16,7 +18,6 @@ public class CommandHandler
     private readonly Dictionary<string, string> custodianCodeToLaNameDict =
         LocalAuthorityData.LocalAuthorityNamesByCustodianCode;
 
-    private readonly AdminAction adminAction;
     private readonly IOutputProvider outputProvider;
 
     public CommandHandler(AdminAction adminAction, IOutputProvider outputProvider)
@@ -76,6 +77,7 @@ public class CommandHandler
             outputProvider.Output("Please specify custodian codes to remove from user");
             return;
         }
+
         var userConfirmation = ConfirmRemoveCustodianCodes(user.EmailAddress, custodianCodes);
         if (!userConfirmation) return;
 
@@ -145,7 +147,8 @@ public class CommandHandler
         }
     }
 
-    private bool ConfirmAddCustodianCodes(string userEmailAddress, IReadOnlyCollection<string> custodianCodes, User? user)
+    private bool ConfirmAddCustodianCodes(string userEmailAddress, IReadOnlyCollection<string> custodianCodes,
+        User? user)
     {
         return ConfirmChangesToDatabase(userEmailAddress, () =>
         {
@@ -191,7 +194,8 @@ public class CommandHandler
                 PrintCodes(consortiumCodes, code => consortiumCodeToConsortiumNameDict[code]);
 
                 // flag the need to remove access for any LAs in the new consortia
-                var ownedCustodianCodesInConsortia = adminAction.GetOwnedCustodianCodesInConsortia(user, consortiumCodes);
+                var ownedCustodianCodesInConsortia =
+                    adminAction.GetOwnedCustodianCodesInConsortia(user, consortiumCodes);
 
                 outputProvider.Output("Remove the following Local Authorities in these Consortia:");
                 PrintCodes(ownedCustodianCodesInConsortia, code =>

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -139,9 +139,9 @@ public class CommandHandler
     private void OutputCouldNotFindAuthorityException(string wrapperMessage, CouldNotFindAuthorityException couldNotFindAuthorityException)
     {
         outputProvider.Output("!!! Error occured during operation !!!");
-        outputProvider.Output($"{wrapperMessage}");
+        outputProvider.Output(wrapperMessage);
         outputProvider.Output($"Invalid Codes: {string.Join(", ", couldNotFindAuthorityException.InvalidCodes)}");
-        outputProvider.Output($"{couldNotFindAuthorityException.Message}");
+        outputProvider.Output(couldNotFindAuthorityException.Message);
         outputProvider.Output("No data has been changed.");
     }
 

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -1,0 +1,331 @@
+using HerPortal.BusinessLogic.Models;
+
+namespace HerPortal.ManagementShell;
+
+public class CommandHandler
+{
+    private readonly Dictionary<string, string> consortiumCodeToConsortiumNameDict =
+        ConsortiumData.ConsortiumNamesByConsortiumCode;
+
+    private readonly Dictionary<string, string> custodianCodeToConsortiumNameDict =
+        LocalAuthorityData.LocalAuthorityConsortiumCodeByCustodianCode
+            .ToDictionary(
+                kvp => kvp.Key,
+                kvp => ConsortiumData.ConsortiumNamesByConsortiumCode[kvp.Value]);
+
+    private readonly Dictionary<string, string> custodianCodeToLaNameDict =
+        LocalAuthorityData.LocalAuthorityNamesByCustodianCode;
+
+    private readonly AdminAction adminAction;
+    private readonly IOutputProvider outputProvider;
+
+    public CommandHandler(AdminAction adminAction, IOutputProvider outputProvider)
+    {
+        this.adminAction = adminAction;
+        this.outputProvider = outputProvider;
+    }
+
+    public User? GetUser(string emailAddress)
+    {
+        return adminAction.GetUser(emailAddress);
+    }
+
+    public void TryRemoveUser(User? user)
+    {
+        if (user == null)
+        {
+            outputProvider.Output("User not found");
+            return;
+        }
+
+        var deletionConfirmation = outputProvider.Confirm(
+            $"Attention! This will delete user {user.EmailAddress} and all associated rows from the database. Are you sure you want to commit this transaction? (y/n)");
+        if (!deletionConfirmation) return;
+
+        adminAction.RemoveUser(user);
+    }
+
+    public void CreateOrUpdateUserWithLas(string userEmailAddress, IReadOnlyCollection<string> custodianCodes)
+    {
+        var (user, userStatus) = CheckUserStatus(userEmailAddress);
+
+        var confirmation = ConfirmAddCustodianCodes(userEmailAddress, custodianCodes, user);
+
+        if (confirmation)
+            switch (userStatus)
+            {
+                case AdminAction.UserStatus.Active:
+                    TryAddLas(user, custodianCodes);
+                    break;
+                case AdminAction.UserStatus.New:
+                    TryCreateUser(userEmailAddress, custodianCodes, null);
+                    break;
+            }
+    }
+
+    public void TryRemoveLas(User? user, IReadOnlyCollection<string> custodianCodes)
+    {
+        if (user == null)
+        {
+            outputProvider.Output("User not found");
+            return;
+        }
+
+        if (custodianCodes.Count == 0)
+        {
+            outputProvider.Output("Please specify custodian codes to remove from user");
+            return;
+        }
+        var userConfirmation = ConfirmRemoveCustodianCodes(user.EmailAddress, custodianCodes);
+        if (!userConfirmation) return;
+
+        try
+        {
+            adminAction.RemoveLas(user, custodianCodes);
+        }
+        catch (KeyNotFoundException keyNotFoundException)
+        {
+            outputProvider.Output($"Could not remove LAs from user: {keyNotFoundException.Message}");
+        }
+    }
+
+    public void CreateOrUpdateUserWithConsortia(string userEmailAddress, IReadOnlyCollection<string> consortiumCodes)
+    {
+        var (user, userStatus) = CheckUserStatus(userEmailAddress);
+
+        var confirmation = ConfirmAddConsortiumCodes(userEmailAddress, consortiumCodes, user);
+
+        if (confirmation)
+            switch (userStatus)
+            {
+                case AdminAction.UserStatus.Active:
+                    TryAddConsortia(user, consortiumCodes);
+                    break;
+                case AdminAction.UserStatus.New:
+                    TryCreateUser(userEmailAddress, null, consortiumCodes);
+                    break;
+            }
+    }
+
+    public void TryRemoveConsortia(User? user, IReadOnlyCollection<string> consortiumCodes)
+    {
+        if (user == null)
+        {
+            outputProvider.Output("User not found");
+            return;
+        }
+
+        if (consortiumCodes.Count == 0)
+        {
+            outputProvider.Output("Please specify consortium codes to remove from user");
+            return;
+        }
+
+        var userConfirmation = ConfirmRemoveConsortiumCodes(user.EmailAddress, consortiumCodes);
+        if (!userConfirmation) return;
+
+        try
+        {
+            adminAction.RemoveConsortia(user, consortiumCodes);
+        }
+        catch (KeyNotFoundException keyNotFoundException)
+        {
+            outputProvider.Output($"Could not remove Consortia from user: {keyNotFoundException.Message}");
+        }
+    }
+
+    private void PrintCodes(IReadOnlyCollection<string> codes, Func<string, string> codeToName)
+    {
+        if (codes.Count < 1) outputProvider.Output("(None)");
+
+        foreach (var code in codes)
+        {
+            var name = codeToName(code);
+            outputProvider.Output($"{code}: {name}");
+        }
+    }
+
+    private bool ConfirmAddCustodianCodes(string userEmailAddress, IReadOnlyCollection<string> custodianCodes, User? user)
+    {
+        return ConfirmChangesToDatabase(userEmailAddress, () =>
+        {
+            if (user != null)
+            {
+                // flag the need to not add LAs that are in consortia the user owns
+                var custodianCodeInOwnedConsortiumGrouping = custodianCodes.ToLookup(custodianCode =>
+                    adminAction.CustodianCodeIsInOwnedConsortium(user, custodianCode));
+                var custodianCodesNotInOwnedConsortium = custodianCodeInOwnedConsortiumGrouping[false].ToList();
+                var custodianCodesInOwnedConsortium = custodianCodeInOwnedConsortiumGrouping[true].ToList();
+
+                outputProvider.Output("Add the following Local Authorities:");
+                PrintCodes(custodianCodesNotInOwnedConsortium, code => custodianCodeToLaNameDict[code]);
+                outputProvider.Output("Ignore the following Local Authorities already in owned Consortia:");
+                PrintCodes(custodianCodesInOwnedConsortium, code =>
+                    $"{custodianCodeToLaNameDict[code]} ({custodianCodeToConsortiumNameDict[code]})");
+            }
+            else
+            {
+                outputProvider.Output("Add the following Local Authorities:");
+                PrintCodes(custodianCodes, code => custodianCodeToLaNameDict[code]);
+            }
+        });
+    }
+
+    private bool ConfirmRemoveCustodianCodes(string userEmailAddress, IReadOnlyCollection<string> custodianCodes)
+    {
+        return ConfirmChangesToDatabase(userEmailAddress, () =>
+        {
+            outputProvider.Output("Remove the following Local Authorities:");
+            PrintCodes(custodianCodes, code => custodianCodeToLaNameDict[code]);
+        });
+    }
+
+    private bool ConfirmAddConsortiumCodes(string? userEmailAddress, IReadOnlyCollection<string> consortiumCodes,
+        User? user)
+    {
+        return ConfirmChangesToDatabase(userEmailAddress, () =>
+        {
+            if (user != null)
+            {
+                outputProvider.Output("Add the following Consortia:");
+                PrintCodes(consortiumCodes, code => consortiumCodeToConsortiumNameDict[code]);
+
+                // flag the need to remove access for any LAs in the new consortia
+                var ownedCustodianCodesInConsortia = adminAction.GetOwnedCustodianCodesInConsortia(user, consortiumCodes);
+
+                outputProvider.Output("Remove the following Local Authorities in these Consortia:");
+                PrintCodes(ownedCustodianCodesInConsortia, code =>
+                    $"{custodianCodeToLaNameDict[code]} ({custodianCodeToConsortiumNameDict[code]})");
+            }
+            else
+            {
+                outputProvider.Output("Add the following Consortia:");
+                PrintCodes(consortiumCodes, code => consortiumCodeToConsortiumNameDict[code]);
+            }
+        });
+    }
+
+    private bool ConfirmRemoveConsortiumCodes(string? userEmailAddress, IReadOnlyCollection<string> consortiumCodes)
+    {
+        return ConfirmChangesToDatabase(userEmailAddress, () =>
+        {
+            outputProvider.Output("Remove the following Consortia:");
+            PrintCodes(consortiumCodes, code => consortiumCodeToConsortiumNameDict[code]);
+        });
+    }
+
+    private bool ConfirmChangesToDatabase(string? userEmailAddress, Action printAction)
+    {
+        outputProvider.Output(
+            $"You are changing permissions for user {userEmailAddress}:");
+
+        try
+        {
+            printAction();
+        }
+        catch (Exception e)
+        {
+            outputProvider.Output($"{e.Message} Process terminated");
+            return false;
+        }
+
+        var hasUserConfirmed = outputProvider.Confirm("Please confirm (y/n)");
+        if (!hasUserConfirmed) outputProvider.Output("Process cancelled, no changes were made to the database");
+
+        return hasUserConfirmed;
+    }
+
+    private void DisplayUserStatus(Enum status)
+    {
+        switch (status)
+        {
+            case AdminAction.UserStatus.New:
+                outputProvider.Output("User not found in database. A new user will be created");
+                break;
+            case AdminAction.UserStatus.Active:
+                outputProvider.Output("User found in database. LAs will be added to their account");
+                break;
+        }
+    }
+
+    private void TryCreateUser(string userEmailAddress, IReadOnlyCollection<string>? custodianCodes,
+        IReadOnlyCollection<string>? consortiumCodes)
+    {
+        try
+        {
+            adminAction.CreateUser(userEmailAddress, custodianCodes, consortiumCodes);
+        }
+        catch (KeyNotFoundException keyNotFoundException)
+        {
+            outputProvider.Output($"Could not create user: {keyNotFoundException.Message}");
+        }
+    }
+
+    private void TryAddLas(User? user, IReadOnlyCollection<string>? custodianCodes)
+    {
+        if (user == null)
+        {
+            outputProvider.Output("User not found");
+            return;
+        }
+
+        if (custodianCodes == null || custodianCodes.Count < 1)
+        {
+            outputProvider.Output("Please specify custodian codes to add to user");
+            return;
+        }
+
+        try
+        {
+            adminAction.AddLas(user, custodianCodes);
+        }
+        catch (KeyNotFoundException keyNotFoundException)
+        {
+            outputProvider.Output($"Could not add LAs to user: {keyNotFoundException.Message}");
+        }
+    }
+
+    private void TryAddConsortia(User? user, IReadOnlyCollection<string>? consortiumCodes)
+    {
+        if (user == null)
+        {
+            outputProvider.Output("User not found");
+            return;
+        }
+
+        if (consortiumCodes == null || consortiumCodes.Count < 1)
+        {
+            outputProvider.Output("Please specify consortium codes to add to user");
+            return;
+        }
+
+        try
+        {
+            adminAction.AddConsortia(user, consortiumCodes);
+        }
+        catch (KeyNotFoundException keyNotFoundException)
+        {
+            outputProvider.Output($"Could not add Consortia to user: {keyNotFoundException.Message}");
+        }
+    }
+
+    private (User? user, AdminAction.UserStatus userStatus) CheckUserStatus(string userEmailAddress)
+    {
+        var user = adminAction.GetUser(userEmailAddress);
+        var userStatus = adminAction.GetUserStatus(user);
+        DisplayUserStatus(userStatus);
+        outputProvider.Output("");
+
+        outputProvider.Output("!!! ATTENTION! READ CAREFULLY OR RISK A DATA BREACH !!!");
+        outputProvider.Output("");
+        outputProvider.Output(
+            "You are about to grant a user permission to read PERSONALLY IDENTIFIABLE INFORMATION submitted to LAs.");
+        outputProvider.Output(
+            "Take a moment to double check the following list and only continue if you are certain this user should have access to these LAs.");
+        outputProvider.Output(
+            "NB: in particular, you should only do this for LAs that have signed their DSA contracts!");
+        outputProvider.Output("");
+
+        return (user, userStatus);
+    }
+}

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -55,10 +55,10 @@ public class CommandHandler
         if (confirmation)
             switch (userStatus)
             {
-                case AdminAction.UserStatus.Active:
+                case UserAccountStatus.Active:
                     TryAddLas(user, custodianCodes);
                     break;
-                case AdminAction.UserStatus.New:
+                case UserAccountStatus.New:
                     TryCreateUser(userEmailAddress, custodianCodes, null);
                     break;
             }
@@ -100,10 +100,10 @@ public class CommandHandler
         if (confirmation)
             switch (userStatus)
             {
-                case AdminAction.UserStatus.Active:
+                case UserAccountStatus.Active:
                     TryAddConsortia(user, consortiumCodes);
                     break;
-                case AdminAction.UserStatus.New:
+                case UserAccountStatus.New:
                     TryCreateUser(userEmailAddress, null, consortiumCodes);
                     break;
             }
@@ -239,14 +239,14 @@ public class CommandHandler
         return hasUserConfirmed;
     }
 
-    private void DisplayUserStatus(Enum status)
+    private void DisplayUserStatus(UserAccountStatus userAccountStatus)
     {
-        switch (status)
+        switch (userAccountStatus)
         {
-            case AdminAction.UserStatus.New:
+            case UserAccountStatus.New:
                 outputProvider.Output("User not found in database. A new user will be created");
                 break;
-            case AdminAction.UserStatus.Active:
+            case UserAccountStatus.Active:
                 outputProvider.Output("User found in database. LAs will be added to their account");
                 break;
         }
@@ -313,7 +313,7 @@ public class CommandHandler
         }
     }
 
-    private (User? user, AdminAction.UserStatus userStatus) CheckUserStatus(string userEmailAddress)
+    private (User? user, UserAccountStatus userStatus) CheckUserStatus(string userEmailAddress)
     {
         var user = adminAction.GetUser(userEmailAddress);
         var userStatus = adminAction.GetUserStatus(user);

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -261,7 +261,7 @@ public class CommandHandler
         }
     }
 
-    private void TryAddLas(User? user, IReadOnlyCollection<string>? custodianCodes)
+    private void TryAddLas(User? user, IReadOnlyCollection<string> custodianCodes)
     {
         if (user == null)
         {
@@ -269,7 +269,7 @@ public class CommandHandler
             return;
         }
 
-        if (custodianCodes == null || custodianCodes.Count < 1)
+        if (custodianCodes.Count < 1)
         {
             outputProvider.Output("Please specify custodian codes to add to user");
             return;
@@ -285,7 +285,7 @@ public class CommandHandler
         }
     }
 
-    private void TryAddConsortia(User? user, IReadOnlyCollection<string>? consortiumCodes)
+    private void TryAddConsortia(User? user, IReadOnlyCollection<string> consortiumCodes)
     {
         if (user == null)
         {
@@ -293,7 +293,7 @@ public class CommandHandler
             return;
         }
 
-        if (consortiumCodes == null || consortiumCodes.Count < 1)
+        if (consortiumCodes.Count < 1)
         {
             outputProvider.Output("Please specify consortium codes to add to user");
             return;

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -85,9 +85,9 @@ public class CommandHandler
         {
             adminAction.RemoveLas(user, custodianCodes);
         }
-        catch (CommandException commandException)
+        catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            outputProvider.Output($"Could not remove LAs from user: {commandException.Message}");
+            OutputCouldNotFindAuthorityException($"Could not remove Custodian Codes from {user.EmailAddress}.", couldNotFindAuthorityException);
         }
     }
 
@@ -130,10 +130,19 @@ public class CommandHandler
         {
             adminAction.RemoveConsortia(user, consortiumCodes);
         }
-        catch (CommandException commandException)
+        catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            outputProvider.Output($"Could not remove Consortia from user: {commandException.Message}");
+            OutputCouldNotFindAuthorityException($"Could not remove Consortium Codes from {user.EmailAddress}.", couldNotFindAuthorityException);
         }
+    }
+
+    private void OutputCouldNotFindAuthorityException(string wrapperMessage, CouldNotFindAuthorityException couldNotFindAuthorityException)
+    {
+        outputProvider.Output("!!! Error occured during operation !!!");
+        outputProvider.Output($"{wrapperMessage}");
+        outputProvider.Output($"Invalid Codes: {string.Join(", ", couldNotFindAuthorityException.InvalidCodes)}");
+        outputProvider.Output($"{couldNotFindAuthorityException.Message}");
+        outputProvider.Output("No data has been changed.");
     }
 
     private void PrintCodes(IReadOnlyCollection<string> codes, Func<string, string> codeToName)
@@ -259,9 +268,9 @@ public class CommandHandler
         {
             adminAction.CreateUser(userEmailAddress, custodianCodes, consortiumCodes);
         }
-        catch (CommandException commandException)
+        catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            outputProvider.Output($"Could not create user: {commandException.Message}");
+            OutputCouldNotFindAuthorityException($"Could not create user {userEmailAddress}.", couldNotFindAuthorityException);
         }
     }
 
@@ -283,9 +292,9 @@ public class CommandHandler
         {
             adminAction.AddLas(user, custodianCodes);
         }
-        catch (CommandException commandException)
+        catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            outputProvider.Output($"Could not add LAs to user: {commandException.Message}");
+            OutputCouldNotFindAuthorityException($"Could not add Custodian Codes to {user.EmailAddress}.", couldNotFindAuthorityException);
         }
     }
 
@@ -307,9 +316,9 @@ public class CommandHandler
         {
             adminAction.AddConsortia(user, consortiumCodes);
         }
-        catch (CommandException commandException)
+        catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            outputProvider.Output($"Could not add Consortia to user: {commandException.Message}");
+            OutputCouldNotFindAuthorityException($"Could not add Consortium Codes to {user.EmailAddress}.", couldNotFindAuthorityException);
         }
     }
 

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -85,9 +85,9 @@ public class CommandHandler
         {
             adminAction.RemoveLas(user, custodianCodes);
         }
-        catch (KeyNotFoundException keyNotFoundException)
+        catch (CommandException commandException)
         {
-            outputProvider.Output($"Could not remove LAs from user: {keyNotFoundException.Message}");
+            outputProvider.Output($"Could not remove LAs from user: {commandException.Message}");
         }
     }
 
@@ -130,9 +130,9 @@ public class CommandHandler
         {
             adminAction.RemoveConsortia(user, consortiumCodes);
         }
-        catch (KeyNotFoundException keyNotFoundException)
+        catch (CommandException commandException)
         {
-            outputProvider.Output($"Could not remove Consortia from user: {keyNotFoundException.Message}");
+            outputProvider.Output($"Could not remove Consortia from user: {commandException.Message}");
         }
     }
 
@@ -259,9 +259,9 @@ public class CommandHandler
         {
             adminAction.CreateUser(userEmailAddress, custodianCodes, consortiumCodes);
         }
-        catch (KeyNotFoundException keyNotFoundException)
+        catch (CommandException commandException)
         {
-            outputProvider.Output($"Could not create user: {keyNotFoundException.Message}");
+            outputProvider.Output($"Could not create user: {commandException.Message}");
         }
     }
 
@@ -283,9 +283,9 @@ public class CommandHandler
         {
             adminAction.AddLas(user, custodianCodes);
         }
-        catch (KeyNotFoundException keyNotFoundException)
+        catch (CommandException commandException)
         {
-            outputProvider.Output($"Could not add LAs to user: {keyNotFoundException.Message}");
+            outputProvider.Output($"Could not add LAs to user: {commandException.Message}");
         }
     }
 
@@ -307,9 +307,9 @@ public class CommandHandler
         {
             adminAction.AddConsortia(user, consortiumCodes);
         }
-        catch (KeyNotFoundException keyNotFoundException)
+        catch (CommandException commandException)
         {
-            outputProvider.Output($"Could not add Consortia to user: {keyNotFoundException.Message}");
+            outputProvider.Output($"Could not add Consortia to user: {commandException.Message}");
         }
     }
 

--- a/HerPortal.ManagementShell/CouldNotFindAuthorityException.cs
+++ b/HerPortal.ManagementShell/CouldNotFindAuthorityException.cs
@@ -1,0 +1,11 @@
+﻿namespace HerPortal.ManagementShell;
+
+public class CouldNotFindAuthorityException : Exception
+{
+    public readonly List<string> InvalidCodes;
+
+    public CouldNotFindAuthorityException(string message, List<string> invalidCodes) : base(message)
+    {
+        InvalidCodes = invalidCodes;
+    }
+}

--- a/HerPortal.ManagementShell/DatabaseOperation.cs
+++ b/HerPortal.ManagementShell/DatabaseOperation.cs
@@ -25,11 +25,12 @@ public class DatabaseOperation : IDatabaseOperation
             .ToList();
     }
 
-    public List<LocalAuthority>? GetLas(IReadOnlyCollection<string> custodianCodes)
+    public List<LocalAuthority> GetLas(IReadOnlyCollection<string> custodianCodes)
     {
-        if (custodianCodes.Any(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code)))
+        var missingCustodianCode = custodianCodes.SingleOrDefault(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code), null);
+        if (missingCustodianCode != null)
         {
-            return null;
+            throw new KeyNotFoundException($"Custodian Code {missingCustodianCode} not found.");
         }
 
         return custodianCodes
@@ -38,11 +39,12 @@ public class DatabaseOperation : IDatabaseOperation
             .ToList();
     }
 
-    public List<Consortium>? GetConsortia(IReadOnlyCollection<string> consortiumCodes)
+    public List<Consortium> GetConsortia(IReadOnlyCollection<string> consortiumCodes)
     {
-        if (consortiumCodes.Any(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code)))
+        var missingConsortiumCode = consortiumCodes.SingleOrDefault(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code), null);
+        if (missingConsortiumCode != null)
         {
-            return null;
+            throw new KeyNotFoundException($"Consortium Code {missingConsortiumCode} not found.");
         }
 
         return consortiumCodes

--- a/HerPortal.ManagementShell/DatabaseOperation.cs
+++ b/HerPortal.ManagementShell/DatabaseOperation.cs
@@ -27,11 +27,8 @@ public class DatabaseOperation : IDatabaseOperation
 
     public List<LocalAuthority>? GetLas(IReadOnlyCollection<string> custodianCodes)
     {
-        if (custodianCodes.Any(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code)))
-        {
-            return null;
-        }
-        
+        if (custodianCodes.Any(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code))) return null;
+
         return custodianCodes
             .Select(code => dbContext.LocalAuthorities
                 .Single(la => la.CustodianCode == code))
@@ -40,11 +37,8 @@ public class DatabaseOperation : IDatabaseOperation
 
     public List<Consortium>? GetConsortia(IReadOnlyCollection<string> consortiumCodes)
     {
-        if (consortiumCodes.Any(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code)))
-        {
-            return null;
-        }
-        
+        if (consortiumCodes.Any(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code))) return null;
+
         return consortiumCodes
             .Select(code => dbContext.Consortia
                 .Single(la => la.ConsortiumCode == code))
@@ -69,7 +63,8 @@ public class DatabaseOperation : IDatabaseOperation
         }
     }
 
-    public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities, List<Consortium> consortia)
+    public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities,
+        List<Consortium> consortia)
     {
         using var dbContextTransaction = dbContext.Database.BeginTransaction();
         try
@@ -98,10 +93,7 @@ public class DatabaseOperation : IDatabaseOperation
         using var dbContextTransaction = dbContext.Database.BeginTransaction();
         try
         {
-            foreach (var la in lasToRemove)
-            {
-                user?.LocalAuthorities.Remove(la);
-            }
+            foreach (var la in lasToRemove) user?.LocalAuthorities.Remove(la);
 
             dbContext.SaveChanges();
             outputProvider.Output("Operation successful");
@@ -114,19 +106,14 @@ public class DatabaseOperation : IDatabaseOperation
         }
     }
 
-    public void AddConsortiaAndRemoveLasFromUser(User user, List<Consortium> consortia, List<LocalAuthority> localAuthorities)
+    public void AddConsortiaAndRemoveLasFromUser(User user, List<Consortium> consortia,
+        List<LocalAuthority> localAuthorities)
     {
         using var dbContextTransaction = dbContext.Database.BeginTransaction();
         try
         {
-            foreach (var consortium in consortia)
-            {
-                user?.Consortia.Add(consortium);
-            }
-            foreach (var localAuthority in localAuthorities)
-            {
-                user?.LocalAuthorities.Remove(localAuthority);
-            }
+            foreach (var consortium in consortia) user?.Consortia.Add(consortium);
+            foreach (var localAuthority in localAuthorities) user?.LocalAuthorities.Remove(localAuthority);
 
             dbContext.SaveChanges();
             outputProvider.Output("Operation successful");
@@ -144,10 +131,7 @@ public class DatabaseOperation : IDatabaseOperation
         using var dbContextTransaction = dbContext.Database.BeginTransaction();
         try
         {
-            foreach (var consortium in consortia)
-            {
-                user?.Consortia.Remove(consortium);
-            }
+            foreach (var consortium in consortia) user?.Consortia.Remove(consortium);
 
             dbContext.SaveChanges();
             outputProvider.Output("Operation successful");
@@ -166,7 +150,6 @@ public class DatabaseOperation : IDatabaseOperation
         try
         {
             foreach (var la in localAuthorities)
-            {
                 try
                 {
                     user?.LocalAuthorities.Add(la);
@@ -176,7 +159,6 @@ public class DatabaseOperation : IDatabaseOperation
                     outputProvider.Output(e.Message);
                     throw;
                 }
-            }
 
             dbContext.SaveChanges();
             outputProvider.Output("Operation successful");
@@ -195,7 +177,6 @@ public class DatabaseOperation : IDatabaseOperation
         try
         {
             foreach (var consortium in consortia)
-            {
                 try
                 {
                     user?.Consortia.Add(consortium);
@@ -205,7 +186,6 @@ public class DatabaseOperation : IDatabaseOperation
                     outputProvider.Output(e.Message);
                     throw;
                 }
-            }
 
             dbContext.SaveChanges();
             outputProvider.Output("Operation successful");

--- a/HerPortal.ManagementShell/DatabaseOperation.cs
+++ b/HerPortal.ManagementShell/DatabaseOperation.cs
@@ -129,6 +129,27 @@ public class DatabaseOperation : IDatabaseOperation
         }
     }
 
+    public void RemoveConsortiaFromUser(User user, List<Consortium> consortia)
+    {
+        using var dbContextTransaction = dbContext.Database.BeginTransaction();
+        try
+        {
+            foreach (var consortium in consortia)
+            {
+                user?.Consortia.Remove(consortium);
+            }
+
+            dbContext.SaveChanges();
+            outputProvider.Output("Operation successful");
+            dbContextTransaction.Commit();
+        }
+        catch (Exception e)
+        {
+            outputProvider.Output($"Rollback following error in transaction: {e.InnerException?.Message}");
+            dbContextTransaction.Rollback();
+        }
+    }
+
     public void AddLasToUser(User user, List<LocalAuthority> localAuthorities)
     {
         using var dbContextTransaction = dbContext.Database.BeginTransaction();

--- a/HerPortal.ManagementShell/DatabaseOperation.cs
+++ b/HerPortal.ManagementShell/DatabaseOperation.cs
@@ -27,11 +27,11 @@ public class DatabaseOperation : IDatabaseOperation
 
     public List<LocalAuthority> GetLas(IReadOnlyCollection<string> custodianCodes)
     {
-        var missingCustodianCode = custodianCodes.SingleOrDefault(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code), null);
+        var missingCustodianCode =
+            custodianCodes.SingleOrDefault(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code),
+                null);
         if (missingCustodianCode != null)
-        {
             throw new KeyNotFoundException($"Custodian Code {missingCustodianCode} not found.");
-        }
 
         return custodianCodes
             .Select(code => dbContext.LocalAuthorities
@@ -41,11 +41,10 @@ public class DatabaseOperation : IDatabaseOperation
 
     public List<Consortium> GetConsortia(IReadOnlyCollection<string> consortiumCodes)
     {
-        var missingConsortiumCode = consortiumCodes.SingleOrDefault(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code), null);
+        var missingConsortiumCode =
+            consortiumCodes.SingleOrDefault(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code), null);
         if (missingConsortiumCode != null)
-        {
             throw new KeyNotFoundException($"Consortium Code {missingConsortiumCode} not found.");
-        }
 
         return consortiumCodes
             .Select(code => dbContext.Consortia
@@ -144,7 +143,7 @@ public class DatabaseOperation : IDatabaseOperation
         try
         {
             transaction();
-            
+
             dbContext.SaveChanges();
             outputProvider.Output("Operation successful");
             dbContextTransaction.Commit();

--- a/HerPortal.ManagementShell/DatabaseOperation.cs
+++ b/HerPortal.ManagementShell/DatabaseOperation.cs
@@ -27,7 +27,10 @@ public class DatabaseOperation : IDatabaseOperation
 
     public List<LocalAuthority>? GetLas(IReadOnlyCollection<string> custodianCodes)
     {
-        if (custodianCodes.Any(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code))) return null;
+        if (custodianCodes.Any(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code)))
+        {
+            return null;
+        }
 
         return custodianCodes
             .Select(code => dbContext.LocalAuthorities
@@ -37,7 +40,10 @@ public class DatabaseOperation : IDatabaseOperation
 
     public List<Consortium>? GetConsortia(IReadOnlyCollection<string> consortiumCodes)
     {
-        if (consortiumCodes.Any(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code))) return null;
+        if (consortiumCodes.Any(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code)))
+        {
+            return null;
+        }
 
         return consortiumCodes
             .Select(code => dbContext.Consortia

--- a/HerPortal.ManagementShell/DatabaseOperation.cs
+++ b/HerPortal.ManagementShell/DatabaseOperation.cs
@@ -31,7 +31,7 @@ public class DatabaseOperation : IDatabaseOperation
             custodianCodes.SingleOrDefault(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code),
                 null);
         if (missingCustodianCode != null)
-            throw new CommandException($"Custodian Code {missingCustodianCode} not found.");
+            throw new CouldNotFindAuthorityException("Could not find Custodian Code in database.", new List<string> {missingCustodianCode});
 
         return custodianCodes
             .Select(code => dbContext.LocalAuthorities
@@ -44,7 +44,7 @@ public class DatabaseOperation : IDatabaseOperation
         var missingConsortiumCode =
             consortiumCodes.SingleOrDefault(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code), null);
         if (missingConsortiumCode != null)
-            throw new CommandException($"Consortium Code {missingConsortiumCode} not found.");
+            throw new CouldNotFindAuthorityException("Could not find Consortium Code in database.", new List<string> {missingConsortiumCode});
 
         return consortiumCodes
             .Select(code => dbContext.Consortia

--- a/HerPortal.ManagementShell/DatabaseOperation.cs
+++ b/HerPortal.ManagementShell/DatabaseOperation.cs
@@ -25,17 +25,27 @@ public class DatabaseOperation : IDatabaseOperation
             .ToList();
     }
 
-    public List<LocalAuthority> GetLas(IEnumerable<string> custodianCodes)
+    public List<LocalAuthority>? GetLas(IReadOnlyCollection<string> custodianCodes)
     {
+        if (custodianCodes.Any(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code)))
+        {
+            return null;
+        }
+        
         return custodianCodes
             .Select(code => dbContext.LocalAuthorities
                 .Single(la => la.CustodianCode == code))
             .ToList();
     }
 
-    public List<Consortium> GetConsortia(IEnumerable<string> custodianCodes)
+    public List<Consortium>? GetConsortia(IReadOnlyCollection<string> consortiumCodes)
     {
-        return custodianCodes
+        if (consortiumCodes.Any(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code)))
+        {
+            return null;
+        }
+        
+        return consortiumCodes
             .Select(code => dbContext.Consortia
                 .Single(la => la.ConsortiumCode == code))
             .ToList();

--- a/HerPortal.ManagementShell/DatabaseOperation.cs
+++ b/HerPortal.ManagementShell/DatabaseOperation.cs
@@ -31,7 +31,7 @@ public class DatabaseOperation : IDatabaseOperation
             custodianCodes.SingleOrDefault(code => !dbContext.LocalAuthorities.Any(la => la.CustodianCode == code),
                 null);
         if (missingCustodianCode != null)
-            throw new KeyNotFoundException($"Custodian Code {missingCustodianCode} not found.");
+            throw new CommandException($"Custodian Code {missingCustodianCode} not found.");
 
         return custodianCodes
             .Select(code => dbContext.LocalAuthorities
@@ -44,7 +44,7 @@ public class DatabaseOperation : IDatabaseOperation
         var missingConsortiumCode =
             consortiumCodes.SingleOrDefault(code => !dbContext.Consortia.Any(la => la.ConsortiumCode == code), null);
         if (missingConsortiumCode != null)
-            throw new KeyNotFoundException($"Consortium Code {missingConsortiumCode} not found.");
+            throw new CommandException($"Consortium Code {missingConsortiumCode} not found.");
 
         return consortiumCodes
             .Select(code => dbContext.Consortia

--- a/HerPortal.ManagementShell/DatabaseOperation.cs
+++ b/HerPortal.ManagementShell/DatabaseOperation.cs
@@ -32,6 +32,14 @@ public class DatabaseOperation : IDatabaseOperation
             .ToList();
     }
 
+    public List<Consortium> GetConsortia(string[] custodianCodes)
+    {
+        return custodianCodes
+            .Select(code => dbContext.Consortia
+                .Single(la => la.ConsortiumCode == code))
+            .ToList();
+    }
+
     public void RemoveUserOrLogError(User user)
     {
         using var dbContextTransaction = dbContext.Database.BeginTransaction();
@@ -50,7 +58,7 @@ public class DatabaseOperation : IDatabaseOperation
         }
     }
 
-    public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities)
+    public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities, List<Consortium> consortia)
     {
         using var dbContextTransaction = dbContext.Database.BeginTransaction();
         try
@@ -59,7 +67,8 @@ public class DatabaseOperation : IDatabaseOperation
             {
                 EmailAddress = userEmailAddress,
                 HasLoggedIn = false,
-                LocalAuthorities = localAuthorities
+                LocalAuthorities = localAuthorities,
+                Consortia = consortia
             };
             dbContext.Add(newLaUser);
             dbContext.SaveChanges();

--- a/HerPortal.ManagementShell/IDatabaseOperation.cs
+++ b/HerPortal.ManagementShell/IDatabaseOperation.cs
@@ -5,11 +5,12 @@ namespace HerPortal.ManagementShell;
 public interface IDatabaseOperation
 {
     public List<User> GetUsersWithLocalAuthoritiesAndConsortia();
-    public List<LocalAuthority> GetLas(string[] custodianCodes);
-    public List<Consortium> GetConsortia(string[] consortiumCodes);
+    public List<LocalAuthority> GetLas(IEnumerable<string> custodianCodes);
+    public List<Consortium> GetConsortia(IEnumerable<string> consortiumCodes);
     public void RemoveUserOrLogError(User user);
     public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities, List<Consortium> consortia);
     public void AddLasToUser(User user, List<LocalAuthority> localAuthorities);
     public void AddConsortiaToUser(User user, List<Consortium> consortia);
     public void RemoveLasFromUser(User user, List<LocalAuthority> localAuthorities);
+    public void AddConsortiaAndRemoveLasFromUser(User user, List<Consortium> consortia, List<LocalAuthority> localAuthorities);
 }

--- a/HerPortal.ManagementShell/IDatabaseOperation.cs
+++ b/HerPortal.ManagementShell/IDatabaseOperation.cs
@@ -5,8 +5,8 @@ namespace HerPortal.ManagementShell;
 public interface IDatabaseOperation
 {
     public List<User> GetUsersWithLocalAuthoritiesAndConsortia();
-    public List<LocalAuthority> GetLas(IEnumerable<string> custodianCodes);
-    public List<Consortium> GetConsortia(IEnumerable<string> consortiumCodes);
+    public List<LocalAuthority>? GetLas(IReadOnlyCollection<string> custodianCodes);
+    public List<Consortium>? GetConsortia(IReadOnlyCollection<string> consortiumCodes);
     public void RemoveUserOrLogError(User user);
     public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities, List<Consortium> consortia);
     public void AddLasToUser(User user, List<LocalAuthority> localAuthorities);

--- a/HerPortal.ManagementShell/IDatabaseOperation.cs
+++ b/HerPortal.ManagementShell/IDatabaseOperation.cs
@@ -6,8 +6,9 @@ public interface IDatabaseOperation
 {
     public List<User> GetUsersWithLocalAuthorities();
     public List<LocalAuthority> GetLas(string[] custodianCodes);
+    public List<Consortium> GetConsortia(string[] consortiumCodes);
     public void RemoveUserOrLogError(User user);
-    public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities);
+    public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities, List<Consortium> consortia);
     public void AddLasToUser(User user, List<LocalAuthority> localAuthorities);
     public void RemoveLasFromUser(User user, List<LocalAuthority> localAuthorities);
 }

--- a/HerPortal.ManagementShell/IDatabaseOperation.cs
+++ b/HerPortal.ManagementShell/IDatabaseOperation.cs
@@ -4,11 +4,12 @@ namespace HerPortal.ManagementShell;
 
 public interface IDatabaseOperation
 {
-    public List<User> GetUsersWithLocalAuthorities();
+    public List<User> GetUsersWithLocalAuthoritiesAndConsortia();
     public List<LocalAuthority> GetLas(string[] custodianCodes);
     public List<Consortium> GetConsortia(string[] consortiumCodes);
     public void RemoveUserOrLogError(User user);
     public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities, List<Consortium> consortia);
     public void AddLasToUser(User user, List<LocalAuthority> localAuthorities);
+    public void AddConsortiaToUser(User user, List<Consortium> consortia);
     public void RemoveLasFromUser(User user, List<LocalAuthority> localAuthorities);
 }

--- a/HerPortal.ManagementShell/IDatabaseOperation.cs
+++ b/HerPortal.ManagementShell/IDatabaseOperation.cs
@@ -8,10 +8,16 @@ public interface IDatabaseOperation
     public List<LocalAuthority>? GetLas(IReadOnlyCollection<string> custodianCodes);
     public List<Consortium>? GetConsortia(IReadOnlyCollection<string> consortiumCodes);
     public void RemoveUserOrLogError(User user);
-    public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities, List<Consortium> consortia);
+
+    public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities,
+        List<Consortium> consortia);
+
     public void AddLasToUser(User user, List<LocalAuthority> localAuthorities);
     public void AddConsortiaToUser(User user, List<Consortium> consortia);
     public void RemoveLasFromUser(User user, List<LocalAuthority> localAuthorities);
-    public void AddConsortiaAndRemoveLasFromUser(User user, List<Consortium> consortia, List<LocalAuthority> localAuthorities);
+
+    public void AddConsortiaAndRemoveLasFromUser(User user, List<Consortium> consortia,
+        List<LocalAuthority> localAuthorities);
+
     public void RemoveConsortiaFromUser(User user, List<Consortium> consortia);
 }

--- a/HerPortal.ManagementShell/IDatabaseOperation.cs
+++ b/HerPortal.ManagementShell/IDatabaseOperation.cs
@@ -13,4 +13,5 @@ public interface IDatabaseOperation
     public void AddConsortiaToUser(User user, List<Consortium> consortia);
     public void RemoveLasFromUser(User user, List<LocalAuthority> localAuthorities);
     public void AddConsortiaAndRemoveLasFromUser(User user, List<Consortium> consortia, List<LocalAuthority> localAuthorities);
+    public void RemoveConsortiaFromUser(User user, List<Consortium> consortia);
 }

--- a/HerPortal.ManagementShell/IDatabaseOperation.cs
+++ b/HerPortal.ManagementShell/IDatabaseOperation.cs
@@ -5,8 +5,8 @@ namespace HerPortal.ManagementShell;
 public interface IDatabaseOperation
 {
     public List<User> GetUsersWithLocalAuthoritiesAndConsortia();
-    public List<LocalAuthority>? GetLas(IReadOnlyCollection<string> custodianCodes);
-    public List<Consortium>? GetConsortia(IReadOnlyCollection<string> consortiumCodes);
+    public List<LocalAuthority> GetLas(IReadOnlyCollection<string> custodianCodes);
+    public List<Consortium> GetConsortia(IReadOnlyCollection<string> consortiumCodes);
     public void RemoveUserOrLogError(User user);
 
     public void CreateUserOrLogError(string userEmailAddress, List<LocalAuthority> localAuthorities,

--- a/HerPortal.ManagementShell/NewUserStatus.cs
+++ b/HerPortal.ManagementShell/NewUserStatus.cs
@@ -1,0 +1,7 @@
+﻿namespace HerPortal.ManagementShell;
+
+public enum UserAccountStatus
+{
+    New,
+    Active
+}

--- a/HerPortal.ManagementShell/Program.cs
+++ b/HerPortal.ManagementShell/Program.cs
@@ -53,7 +53,7 @@ namespace HerPortal.ManagementShell
                     adminAction.RemoveLas(adminAction.GetUser(userEmailAddress), custodianCodes);
                     return;
                 case Subcommand.AddLas:
-                    adminAction.CreateOrUpdateUser(userEmailAddress, custodianCodes);
+                    adminAction.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
                     return;
                 default:
                     outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");

--- a/HerPortal.ManagementShell/Program.cs
+++ b/HerPortal.ManagementShell/Program.cs
@@ -26,7 +26,8 @@ namespace HerPortal.ManagementShell
             using var context = new HerDbContext(contextOptions);
             var outputProvider = new OutputProvider();
             var dbOperation = new DatabaseOperation(context, outputProvider);
-            var adminAction = new AdminAction(dbOperation, outputProvider);
+            var adminAction = new AdminAction(dbOperation);
+            var commandHandler = new CommandHandler(adminAction, outputProvider);
 
             Subcommand command;
             var userEmailAddress = "";
@@ -49,19 +50,19 @@ namespace HerPortal.ManagementShell
             switch (command)
             {
                 case Subcommand.RemoveUser:
-                    adminAction.TryRemoveUser(adminAction.GetUser(userEmailAddress));
-                    return;
-                case Subcommand.RemoveLas:
-                    adminAction.RemoveLas(adminAction.GetUser(userEmailAddress), codes);
+                    commandHandler.TryRemoveUser(commandHandler.GetUser(userEmailAddress));
                     return;
                 case Subcommand.AddLas:
-                    adminAction.CreateOrUpdateUserWithLas(userEmailAddress, codes);
+                    commandHandler.CreateOrUpdateUserWithLas(userEmailAddress, codes);
                     return;
                 case Subcommand.AddConsortia:
-                    adminAction.CreateOrUpdateUserWithConsortia(userEmailAddress, codes);
+                    commandHandler.CreateOrUpdateUserWithConsortia(userEmailAddress, codes);
                     break;
+                case Subcommand.RemoveLas:
+                    commandHandler.TryRemoveLas(commandHandler.GetUser(userEmailAddress), codes);
+                    return;
                 case Subcommand.RemoveConsortia:
-                    adminAction.RemoveConsortia(adminAction.GetUser(userEmailAddress), codes);
+                    commandHandler.TryRemoveConsortia(commandHandler.GetUser(userEmailAddress), codes);
                     break;
                 default:
                     outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");

--- a/HerPortal.ManagementShell/Program.cs
+++ b/HerPortal.ManagementShell/Program.cs
@@ -1,73 +1,73 @@
-﻿using HerPortal.Data;
+﻿using System.Diagnostics.CodeAnalysis;
+using HerPortal.Data;
 using Microsoft.EntityFrameworkCore;
-using System.Diagnostics.CodeAnalysis;
 
-namespace HerPortal.ManagementShell
+namespace HerPortal.ManagementShell;
+
+[ExcludeFromCodeCoverage]
+public static class Program
 {
-    [ExcludeFromCodeCoverage]
-    public static class Program
+    public static void Main(string[] args)
     {
-        private enum Subcommand
+        var contextOptions = new DbContextOptionsBuilder<HerDbContext>()
+            .UseNpgsql(
+                Environment.GetEnvironmentVariable("ConnectionStrings__PostgreSQLConnection") ??
+                @"UserId=postgres;Password=postgres;Server=localhost;Port=5432;Database=herportaldev;Integrated Security=true;Include Error Detail=true;Pooling=true")
+            .Options;
+
+        using var context = new HerDbContext(contextOptions);
+        var outputProvider = new OutputProvider();
+        var dbOperation = new DatabaseOperation(context, outputProvider);
+        var adminAction = new AdminAction(dbOperation);
+        var commandHandler = new CommandHandler(adminAction, outputProvider);
+
+        Subcommand command;
+        var userEmailAddress = "";
+        var codes = Array.Empty<string>();
+
+        try
         {
-            AddLas,
-            RemoveLas,
-            RemoveUser,
-            AddConsortia,
-            RemoveConsortia
+            command = Enum.Parse<Subcommand>(args[0], true);
+            userEmailAddress = args[1];
+            codes = args.Skip(2).ToArray();
         }
-        public static void Main(string[] args)
+        catch (Exception)
         {
-            var contextOptions = new DbContextOptionsBuilder<HerDbContext>()
-                .UseNpgsql(
-                    Environment.GetEnvironmentVariable("ConnectionStrings__PostgreSQLConnection") ??
-                    @"UserId=postgres;Password=postgres;Server=localhost;Port=5432;Database=herportaldev;Integrated Security=true;Include Error Detail=true;Pooling=true")
-                .Options;
+            var allSubcommands = string.Join(", ", Enum.GetValues<Subcommand>());
+            outputProvider.Output(
+                $"Please specify a valid subcommand - available options are: {allSubcommands}");
+            return;
+        }
 
-            using var context = new HerDbContext(contextOptions);
-            var outputProvider = new OutputProvider();
-            var dbOperation = new DatabaseOperation(context, outputProvider);
-            var adminAction = new AdminAction(dbOperation);
-            var commandHandler = new CommandHandler(adminAction, outputProvider);
-
-            Subcommand command;
-            var userEmailAddress = "";
-            var codes = Array.Empty<string>();
-
-            try
-            {
-                command = Enum.Parse<Subcommand>(args[0], true);
-                userEmailAddress = args[1];
-                codes = args.Skip(2).ToArray();
-            }
-            catch (Exception)
-            {
-                var allSubcommands = string.Join(", ", Enum.GetValues<Subcommand>());
-                outputProvider.Output(
-                    $"Please specify a valid subcommand - available options are: {allSubcommands}");
+        switch (command)
+        {
+            case Subcommand.RemoveUser:
+                commandHandler.TryRemoveUser(commandHandler.GetUser(userEmailAddress));
                 return;
-            }
-
-            switch (command)
-            {
-                case Subcommand.RemoveUser:
-                    commandHandler.TryRemoveUser(commandHandler.GetUser(userEmailAddress));
-                    return;
-                case Subcommand.AddLas:
-                    commandHandler.CreateOrUpdateUserWithLas(userEmailAddress, codes);
-                    return;
-                case Subcommand.AddConsortia:
-                    commandHandler.CreateOrUpdateUserWithConsortia(userEmailAddress, codes);
-                    break;
-                case Subcommand.RemoveLas:
-                    commandHandler.TryRemoveLas(commandHandler.GetUser(userEmailAddress), codes);
-                    return;
-                case Subcommand.RemoveConsortia:
-                    commandHandler.TryRemoveConsortia(commandHandler.GetUser(userEmailAddress), codes);
-                    break;
-                default:
-                    outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");
-                    return;
-            }
+            case Subcommand.AddLas:
+                commandHandler.CreateOrUpdateUserWithLas(userEmailAddress, codes);
+                return;
+            case Subcommand.AddConsortia:
+                commandHandler.CreateOrUpdateUserWithConsortia(userEmailAddress, codes);
+                break;
+            case Subcommand.RemoveLas:
+                commandHandler.TryRemoveLas(commandHandler.GetUser(userEmailAddress), codes);
+                return;
+            case Subcommand.RemoveConsortia:
+                commandHandler.TryRemoveConsortia(commandHandler.GetUser(userEmailAddress), codes);
+                break;
+            default:
+                outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");
+                return;
         }
+    }
+
+    private enum Subcommand
+    {
+        AddLas,
+        RemoveLas,
+        RemoveUser,
+        AddConsortia,
+        RemoveConsortia
     }
 }

--- a/HerPortal.ManagementShell/Program.cs
+++ b/HerPortal.ManagementShell/Program.cs
@@ -12,7 +12,8 @@ namespace HerPortal.ManagementShell
             AddLas,
             RemoveLas,
             RemoveUser,
-            AddConsortia
+            AddConsortia,
+            RemoveConsortia
         }
         public static void Main(string[] args)
         {
@@ -58,6 +59,9 @@ namespace HerPortal.ManagementShell
                     return;
                 case Subcommand.AddConsortia:
                     adminAction.CreateOrUpdateUserWithConsortia(userEmailAddress, codes);
+                    break;
+                case Subcommand.RemoveConsortia:
+                    adminAction.RemoveConsortia(adminAction.GetUser(userEmailAddress), codes);
                     break;
                 default:
                     outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");

--- a/HerPortal.ManagementShell/Program.cs
+++ b/HerPortal.ManagementShell/Program.cs
@@ -11,7 +11,8 @@ namespace HerPortal.ManagementShell
         {
             AddLas,
             RemoveLas,
-            RemoveUser
+            RemoveUser,
+            AddConsortia
         }
         public static void Main(string[] args)
         {
@@ -28,13 +29,13 @@ namespace HerPortal.ManagementShell
 
             Subcommand command;
             var userEmailAddress = "";
-            var custodianCodes = Array.Empty<string>();
+            var codes = Array.Empty<string>();
 
             try
             {
                 command = Enum.Parse<Subcommand>(args[0], true);
                 userEmailAddress = args[1];
-                custodianCodes = args.Skip(2).ToArray();
+                codes = args.Skip(2).ToArray();
             }
             catch (Exception)
             {
@@ -50,11 +51,14 @@ namespace HerPortal.ManagementShell
                     adminAction.TryRemoveUser(adminAction.GetUser(userEmailAddress));
                     return;
                 case Subcommand.RemoveLas:
-                    adminAction.RemoveLas(adminAction.GetUser(userEmailAddress), custodianCodes);
+                    adminAction.RemoveLas(adminAction.GetUser(userEmailAddress), codes);
                     return;
                 case Subcommand.AddLas:
-                    adminAction.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
+                    adminAction.CreateOrUpdateUserWithLas(userEmailAddress, codes);
                     return;
+                case Subcommand.AddConsortia:
+                    adminAction.CreateOrUpdateUserWithConsortia(userEmailAddress, codes);
+                    break;
                 default:
                     outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");
                     return;

--- a/HerPortal.UnitTests/Builders/UserBuilder.cs
+++ b/HerPortal.UnitTests/Builders/UserBuilder.cs
@@ -29,6 +29,12 @@ public class UserBuilder
         return this;
     }
 
+    public UserBuilder WithConsortia(List<Consortium> consortia)
+    {
+        user.Consortia = consortia;
+        return this;
+    }
+
     public UserBuilder WithHasLoggedIn(bool hasLoggedIn)
     {
         user.HasLoggedIn = hasLoggedIn;

--- a/HerPortal.UnitTests/Builders/UserBuilder.cs
+++ b/HerPortal.UnitTests/Builders/UserBuilder.cs
@@ -14,7 +14,8 @@ public class UserBuilder
             Id = 13,
             EmailAddress = emailAddress,
             HasLoggedIn = true,
-            LocalAuthorities = new List<LocalAuthority>()
+            LocalAuthorities = new List<LocalAuthority>(),
+            Consortia = new List<Consortium>()
         };
     }
 

--- a/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
@@ -82,6 +82,7 @@ public class AdminActionTests
             }
         };
         mockDatabaseOperation.Setup(mock => mock.GetLas(custodianCodes)).Returns(las);
+        mockDatabaseOperation.Setup(mock => mock.GetConsortia(It.IsAny<string[]>())).Returns(new List<Consortium>());
 
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
@@ -470,6 +471,7 @@ public class AdminActionTests
             }
         };
         mockDatabaseOperation.Setup(mock => mock.GetConsortia(consortiumCodes)).Returns(consortia);
+        mockDatabaseOperation.Setup(mock => mock.GetLas(It.IsAny<string[]>())).Returns(new List<LocalAuthority>());
 
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
@@ -694,7 +696,7 @@ public class AdminActionTests
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
 
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output("2372: Blackburn With Darwen"), Times.Once());
+        mockOutputProvider.Verify(mock => mock.Output("2372: Blackburn With Darwen (Blackpool)"), Times.Once());
     }
 
     [Test]

--- a/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
@@ -1,17 +1,17 @@
 using System;
 using System.Collections.Generic;
 using HerPortal.BusinessLogic.Models;
+using HerPortal.ManagementShell;
 using Moq;
 using NUnit.Framework;
 using Tests.Builders;
-using HerPortal.ManagementShell;
 
 namespace Tests.ManagementShell;
 
 public class AdminActionTests
 {
-    private Mock<IOutputProvider> mockOutputProvider;
     private Mock<IDatabaseOperation> mockDatabaseOperation;
+    private Mock<IOutputProvider> mockOutputProvider;
     private AdminAction underTest;
 
     [SetUp]
@@ -71,7 +71,7 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        var custodianCodes = new[] { "9052"};
+        var custodianCodes = new[] { "9052" };
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
         var las = new List<LocalAuthority>
         {
@@ -82,10 +82,10 @@ public class AdminActionTests
             }
         };
         mockDatabaseOperation.Setup(mock => mock.GetLas(custodianCodes)).Returns(las);
-        
+
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
-        
+
         // Assert
         mockDatabaseOperation.Verify(
             mock => mock.CreateUserOrLogError(userEmailAddress, las, It.IsAny<List<Consortium>>()), Times.Once());
@@ -97,7 +97,7 @@ public class AdminActionTests
         // Arrange
         var currentLa = new List<LocalAuthority>
         {
-            new LocalAuthority()
+            new()
             {
                 Id = 2,
                 CustodianCode = "2525"
@@ -110,10 +110,10 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").WithLocalAuthorities(currentLa).Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        
+
         var custodianCodes = new[] { "9052" };
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
-        
+
         var lasToAdd = new List<LocalAuthority>
         {
             new()
@@ -123,10 +123,10 @@ public class AdminActionTests
             }
         };
         mockDatabaseOperation.Setup(mock => mock.GetLas(custodianCodes)).Returns(lasToAdd);
-        
+
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
-        
+
         // Assert
         mockDatabaseOperation.Verify(mock => mock.AddLasToUser(users[0], lasToAdd));
     }
@@ -148,7 +148,8 @@ public class AdminActionTests
         };
 
         var userEmailAddress = "existinguser@email.com";
-        var user = new UserBuilder(userEmailAddress).WithLocalAuthorities(new List<LocalAuthority> { laToRemove, laToKeep }).Build();
+        var user = new UserBuilder(userEmailAddress)
+            .WithLocalAuthorities(new List<LocalAuthority> { laToRemove, laToKeep }).Build();
         var users = new List<User> { user };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
@@ -159,7 +160,8 @@ public class AdminActionTests
         underTest.RemoveLas(user, custodianCodes);
 
         // Assert
-        mockDatabaseOperation.Verify(mock => mock.RemoveLasFromUser(user, new List<LocalAuthority> { laToRemove }), Times.Once());
+        mockDatabaseOperation.Verify(mock => mock.RemoveLasFromUser(user, new List<LocalAuthority> { laToRemove }),
+            Times.Once());
     }
 
     [Test]
@@ -172,10 +174,10 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         mockOutputProvider.Setup(mock => mock.Confirm(It.IsAny<string>())).Returns(true);
-        
+
         // Act
         underTest.TryRemoveUser(users[0]);
-        
+
         // Assert
         mockDatabaseOperation.Verify(mock => mock.RemoveUserOrLogError(users[0]), Times.Once());
     }
@@ -194,7 +196,7 @@ public class AdminActionTests
 
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, Array.Empty<string>());
-        
+
         // Assert
         mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
     }
@@ -214,18 +216,19 @@ public class AdminActionTests
             CustodianCode = "2525",
             Id = 7
         };
-        
+
         var userEmailAddress = "existinguser@email.com";
-        var user = new UserBuilder(userEmailAddress).WithLocalAuthorities(new List<LocalAuthority> { usersCurrentLa }).Build();
+        var user = new UserBuilder(userEmailAddress).WithLocalAuthorities(new List<LocalAuthority> { usersCurrentLa })
+            .Build();
         var users = new List<User> { user };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         var custodianCodes = new[] { laToRemove.CustodianCode };
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
-        
+
         // Act
         underTest.RemoveLas(user, custodianCodes);
-        
+
         // Assert
         mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
     }
@@ -240,11 +243,11 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        var listWithCustodianCodeNotInDict = new [] { "1111" };
+        var listWithCustodianCodeNotInDict = new[] { "1111" };
 
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, listWithCustodianCodeNotInDict);
-        
+
         // Assert
         mockOutputProvider.Verify(mock =>
             mock.Output("The given key '1111' was not present in the dictionary. Process terminated"));
@@ -260,7 +263,7 @@ public class AdminActionTests
             new UserBuilder("userindb@email.com").Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        var custodianCodes = new[] { "9052"};
+        var custodianCodes = new[] { "9052" };
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, false);
         var lasToAdd = new List<LocalAuthority>
         {
@@ -270,10 +273,10 @@ public class AdminActionTests
                 CustodianCode = "9052"
             }
         };
-        
+
         // Act
         underTest.RemoveLas(null, custodianCodes);
-        
+
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("User not found"));
     }
@@ -288,7 +291,7 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        var custodianCodes = new[] { "9052"};
+        var custodianCodes = new[] { "9052" };
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, false);
         var lasToAdd = new List<LocalAuthority>
         {
@@ -298,16 +301,16 @@ public class AdminActionTests
                 CustodianCode = "9052"
             }
         };
-        
+
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
-        
+
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("Process cancelled, no changes were made to the database"));
         mockDatabaseOperation.Verify(
             mock => mock.CreateUserOrLogError(userEmailAddress, lasToAdd, It.IsAny<List<Consortium>>()), Times.Never());
     }
-    
+
     [Test]
     public void CreateOrUpdateUserWithLas_AsksForConfirmation()
     {
@@ -318,15 +321,15 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        var custodianCodes = new[] { "9052"};
-        
+        var custodianCodes = new[] { "9052" };
+
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
 
         // Assert
         mockOutputProvider.Verify(mock => mock.Confirm("Please confirm (y/n)"), Times.Once);
     }
-    
+
     [Test]
     public void CreateOrUpdateUserWithLas_DisplaysCorrectUserStatus_WhenUserActive()
     {
@@ -337,14 +340,15 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        var custodianCodes = new[] { "9052"};
+        var custodianCodes = new[] { "9052" };
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
-        
+
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output("User found in database. LAs will be added to their account"), Times.Once());
+        mockOutputProvider.Verify(mock => mock.Output("User found in database. LAs will be added to their account"),
+            Times.Once());
     }
-    
+
     [Test]
     public void CreateOrUpdateUserWithLas_DisplaysCorrectUserStatus_WhenUserInactive()
     {
@@ -358,11 +362,12 @@ public class AdminActionTests
         var custodianCodes = new[] { "9052" };
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
-        
+
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output("User not found in database. A new user will be created"), Times.Once());
+        mockOutputProvider.Verify(mock => mock.Output("User not found in database. A new user will be created"),
+            Times.Once());
     }
-    
+
     [Test]
     public void CreateOrUpdateUserWithLas_WhenGivenLocalAuthorities_PrintsThem()
     {
@@ -376,13 +381,14 @@ public class AdminActionTests
         var custodianCodes = new[] { "9052", "3805" };
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
-        
+
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("9052: Aberdeenshire"), Times.Once());
         mockOutputProvider.Verify(mock => mock.Output("3805: Adur"), Times.Once());
     }
-    
-    private void SetupConfirmCustodianCodes(IEnumerable<string> custodianCodes, string userEmailAddress, bool confirmation)
+
+    private void SetupConfirmCustodianCodes(IEnumerable<string> custodianCodes, string userEmailAddress,
+        bool confirmation)
     {
         mockOutputProvider
             .Setup(op =>
@@ -390,18 +396,15 @@ public class AdminActionTests
                     $"You are changing permissions for user {userEmailAddress} for the following Local Authorities:"));
         mockOutputProvider
             .Setup(op => op.Output("Add the following Local Authorities:"));
-        foreach (var code in custodianCodes)
-        {
-            mockOutputProvider.Setup(op => op.Output("Code: Local Authority"));
-        }
+        foreach (var code in custodianCodes) mockOutputProvider.Setup(op => op.Output("Code: Local Authority"));
         mockOutputProvider
-            .Setup(op => 
+            .Setup(op =>
                 op.Output("Ignore the following Local Authorities already in owned Consortia:"));
         mockOutputProvider.Setup(op => op.Output("(None)"));
 
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(confirmation);
     }
-    
+
     [Test]
     public void CreateOrUpdateUserWithConsortia_ConfirmsCustodianCodesWhenUpdating()
     {
@@ -443,13 +446,14 @@ public class AdminActionTests
             }
         };
         mockDatabaseOperation.Setup(mock => mock.GetConsortia(consortiumCodes)).Returns(consortia);
-        
+
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
-        
+
         // Assert
         mockDatabaseOperation.Verify(
-            mock => mock.CreateUserOrLogError(userEmailAddress, It.IsAny<List<LocalAuthority>>(), consortia), Times.Once());
+            mock => mock.CreateUserOrLogError(userEmailAddress, It.IsAny<List<LocalAuthority>>(), consortia),
+            Times.Once());
     }
 
     [Test]
@@ -471,10 +475,10 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").WithConsortia(currentConsortia).Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        
+
         var custodianCodes = new[] { "C_0002" };
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
-        
+
         var consortiaToAdd = new List<Consortium>
         {
             new()
@@ -484,10 +488,10 @@ public class AdminActionTests
             }
         };
         mockDatabaseOperation.Setup(mock => mock.GetConsortia(custodianCodes)).Returns(consortiaToAdd);
-        
+
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, custodianCodes);
-        
+
         // Assert
         mockDatabaseOperation.Verify(mock => mock.AddConsortiaToUser(users[0], consortiaToAdd));
     }
@@ -507,7 +511,7 @@ public class AdminActionTests
 
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, Array.Empty<string>());
-        
+
         // Assert
         mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
     }
@@ -523,11 +527,11 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        var listWithCustodianCodeNotInDict = new [] { "C_1111" };
+        var listWithCustodianCodeNotInDict = new[] { "C_1111" };
 
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, listWithCustodianCodeNotInDict);
-        
+
         // Assert
         mockOutputProvider.Verify(mock =>
             mock.Output("The given key 'C_1111' was not present in the dictionary. Process terminated"));
@@ -561,8 +565,8 @@ public class AdminActionTests
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("Process cancelled, no changes were made to the database"));
         mockDatabaseOperation.Verify(
-            mock => mock.CreateUserOrLogError(userEmailAddress, It.IsAny<List<LocalAuthority>>(), consortiaToAdd), Times.Never());
-
+            mock => mock.CreateUserOrLogError(userEmailAddress, It.IsAny<List<LocalAuthority>>(), consortiaToAdd),
+            Times.Never());
     }
 
     [Test]
@@ -576,14 +580,14 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var consortiumCodes = new[] { "C_0002" };
-        
+
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
 
         // Assert
         mockOutputProvider.Verify(mock => mock.Confirm("Please confirm (y/n)"), Times.Once);
     }
-    
+
     [Test]
     public void CreateOrUpdateUserWithConsortia_DisplaysCorrectUserStatus_WhenUserActive()
     {
@@ -593,16 +597,17 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-   
+
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var consortiumCodes = new[] { "C_0002" };
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
-        
+
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output("User found in database. LAs will be added to their account"), Times.Once());
+        mockOutputProvider.Verify(mock => mock.Output("User found in database. LAs will be added to their account"),
+            Times.Once());
     }
-    
+
     [Test]
     public void CreateOrUpdateUserWithConsortia_DisplaysCorrectUserStatus_WhenUserInactive()
     {
@@ -616,11 +621,12 @@ public class AdminActionTests
         var consortiumCodes = new[] { "C_0002" };
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
-        
+
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output("User not found in database. A new user will be created"), Times.Once());
+        mockOutputProvider.Verify(mock => mock.Output("User not found in database. A new user will be created"),
+            Times.Once());
     }
-    
+
     [Test]
     public void CreateOrUpdateUserWithConsortia_WhenGivenConsortia_PrintsThem()
     {
@@ -634,12 +640,12 @@ public class AdminActionTests
         var consortiumCodes = new[] { "C_0002", "C_0003" };
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
-        
+
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("C_0002: Blackpool"), Times.Once());
         mockOutputProvider.Verify(mock => mock.Output("C_0003: Bristol"), Times.Once());
     }
-    
+
     [Test]
     public void CreateOrUpdateUserWithConsortia_WhenUserOwnsLocalAuthorityInConsortium_PrintsThem()
     {
@@ -652,7 +658,7 @@ public class AdminActionTests
                 CustodianCode = "2372"
             }
         };
-        
+
         const string userEmailAddress = "existinguser@email.com";
         var users = new List<User>
         {
@@ -662,21 +668,19 @@ public class AdminActionTests
         var consortiumCodes = new[] { "C_0002" };
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
-        
+
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("2372: Blackburn With Darwen"), Times.Once());
     }
-    
-    private void SetupConfirmConsortiumCodes(IEnumerable<string> consortiumCodes, string userEmailAddress, bool confirmation)
+
+    private void SetupConfirmConsortiumCodes(IEnumerable<string> consortiumCodes, string userEmailAddress,
+        bool confirmation)
     {
         mockOutputProvider
             .Setup(op =>
                 op.Output(
                     $"You are changing permissions for user {userEmailAddress} for the following consortiums: "));
-        foreach (var code in consortiumCodes)
-        {
-            mockOutputProvider.Setup(op => op.Output("Code: Consortium"));
-        }
+        foreach (var code in consortiumCodes) mockOutputProvider.Setup(op => op.Output("Code: Consortium"));
 
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(confirmation);
     }

--- a/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
@@ -442,6 +442,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "C_0002", "C_0003" };
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
+        mockDatabaseOperation.Setup(mock => mock.GetLas(It.IsAny<List<string>>())).Returns(new List<LocalAuthority>());
 
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, custodianCodes);
@@ -513,6 +514,7 @@ public class AdminActionTests
                 ConsortiumCode = "C_0003"
             }
         };
+        mockDatabaseOperation.Setup(mock => mock.GetLas(It.IsAny<List<string>>())).Returns(new List<LocalAuthority>());
         mockDatabaseOperation.Setup(mock => mock.GetConsortia(consortiumCodes)).Returns(consortiaToAdd);
 
         // Act

--- a/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
@@ -23,7 +23,7 @@ public class AdminActionTests
     }
 
     [Test]
-    public void FindsExistingUserCaseInsensitively_IfInDatabase()
+    public void GetUser_FindsExistingUserCaseInsensitively_IfInDatabase()
     {
         // Arrange
         var users = new List<User>
@@ -32,7 +32,7 @@ public class AdminActionTests
             new UserBuilder("existinguser2@email.com").Build()
         };
         const string userEmailAddress = "ExistingUser@email.com";
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         // Act
         var returnedUser = underTest.GetUser(userEmailAddress);
@@ -42,7 +42,7 @@ public class AdminActionTests
     }
 
     [Test]
-    public void ConfirmsCustodianCodesWhenUpdating()
+    public void CreateOrUpdateUserWithLas_ConfirmsCustodianCodesWhenUpdating()
     {
         // Arrange
         const string userEmailAddress = "existinguser@email.com";
@@ -50,7 +50,7 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052", "2525" };
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
 
@@ -62,7 +62,7 @@ public class AdminActionTests
     }
 
     [Test]
-    public void CreatesNewUser_IfUserNotFoundByDbOperation()
+    public void CreateOrUpdateUserWithLas_CreatesNewUser_IfUserNotFoundByDbOperation()
     {
         // Arrange
         const string userEmailAddress = "newuser@email.com";
@@ -70,7 +70,7 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052"};
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
         var las = new List<LocalAuthority>
@@ -92,7 +92,7 @@ public class AdminActionTests
     }
 
     [Test]
-    public void AddsLasToExistingUser_IfUserFoundByDbOperation()
+    public void CreateOrUpdateUserWithLas_AddsLasToExistingUser_IfUserFoundByDbOperation()
     {
         // Arrange
         var currentLa = new List<LocalAuthority>
@@ -109,7 +109,7 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").WithLocalAuthorities(currentLa).Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         
         var custodianCodes = new[] { "9052"};
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
@@ -132,7 +132,7 @@ public class AdminActionTests
     }
 
     [Test]
-    public void RemovesLasFromExistingUser_IfUserFoundByDbOperation()
+    public void RemoveLas_RemovesLasFromExistingUser_IfUserFoundByDbOperation()
     {
         // Arrange
         var laToRemove = new LocalAuthority
@@ -150,7 +150,7 @@ public class AdminActionTests
         var userEmailAddress = "existinguser@email.com";
         var user = new UserBuilder(userEmailAddress).WithLocalAuthorities(new List<LocalAuthority> { laToRemove, laToKeep }).Build();
         var users = new List<User> { user };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         var custodianCodes = new[] { laToRemove.CustodianCode };
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
@@ -163,14 +163,14 @@ public class AdminActionTests
     }
 
     [Test]
-    public void RemoveUser_IfUserFound_WhenThereIsDeletionConfirmation()
+    public void TryRemoveUser_IfUserFound_WhenThereIsDeletionConfirmation()
     {
         // Arrange
         var users = new List<User>
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         mockOutputProvider.Setup(mock => mock.Confirm(It.IsAny<string>())).Returns(true);
         
         // Act
@@ -181,7 +181,7 @@ public class AdminActionTests
     }
 
     [Test]
-    public void DisplaysErrorMessage_WhenNoLasSpecified_IfUserExists()
+    public void CreateOrUpdateUserWithLas_DisplaysErrorMessage_WhenNoLasSpecified_IfUserExists()
     {
         // Arrange
         var userEmailAddress = "existinguser@email.com";
@@ -189,7 +189,7 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         SetupConfirmCustodianCodes(Array.Empty<string>(), userEmailAddress, true);
 
         // Act
@@ -200,7 +200,7 @@ public class AdminActionTests
     }
 
     [Test]
-    public void DisplaysErrorMessage_IfCustodianCodeToRemove_DoesNotMatchAnyOfExistingUsersLas()
+    public void RemoveLas_DisplaysErrorMessage_IfCustodianCodeToRemove_DoesNotMatchAnyOfExistingUsersLas()
     {
         // Arrange
         var laToRemove = new LocalAuthority
@@ -218,7 +218,7 @@ public class AdminActionTests
         var userEmailAddress = "existinguser@email.com";
         var user = new UserBuilder(userEmailAddress).WithLocalAuthorities(new List<LocalAuthority> { usersCurrentLa }).Build();
         var users = new List<User> { user };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         var custodianCodes = new[] { laToRemove.CustodianCode };
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
@@ -231,7 +231,7 @@ public class AdminActionTests
     }
 
     [Test]
-    public void DisplaysInnerExceptionMessage_IfCustodianCode_IsNotFoundInDict()
+    public void CreateOrUpdateUserWithLas_DisplaysInnerExceptionMessage_IfCustodianCode_IsNotFoundInDict()
     {
         // Arrange
         const string userEmailAddress = "existinguser@email.com";
@@ -239,18 +239,19 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var listWithCustodianCodeNotInDict = new [] { "1111" };
 
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, listWithCustodianCodeNotInDict);
         
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
+        mockOutputProvider.Verify(mock =>
+            mock.Output("The given key '1111' was not present in the dictionary. Process terminated"));
     }
 
     [Test]
-    public void DisplaysErrorMessage_WhenRemovingLas_IfUserNotInDatabase()
+    public void RemoveLas_DisplaysErrorMessage_WhenRemovingLas_IfUserNotInDatabase()
     {
         // Arrange
         const string userEmailAddress = "usernotindb@email.com";
@@ -258,7 +259,7 @@ public class AdminActionTests
         {
             new UserBuilder("userindb@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052"};
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, false);
         var lasToAdd = new List<LocalAuthority>
@@ -278,7 +279,7 @@ public class AdminActionTests
     }
 
     [Test]
-    public void DoesNotCallDbOperation_IfConfirmKeyNotPressed()
+    public void CreateOrUpdateUserWithLas_DoesNotCallDbOperation_IfConfirmKeyNotPressed()
     {
         // Arrange
         const string userEmailAddress = "newuser@email.com";
@@ -286,7 +287,7 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052"};
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, false);
         var lasToAdd = new List<LocalAuthority>
@@ -308,7 +309,7 @@ public class AdminActionTests
     }
     
     [Test]
-    public void AsksForConfirmation()
+    public void CreateOrUpdateUserWithLas_AsksForConfirmation()
     {
         // Arrange
         const string userEmailAddress = "newuser@email.com";
@@ -316,7 +317,7 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052"};
         
         // Act
@@ -327,7 +328,7 @@ public class AdminActionTests
     }
     
     [Test]
-    public void DisplaysCorrectUserStatus_WhenUserActive()
+    public void CreateOrUpdateUserWithLas_DisplaysCorrectUserStatus_WhenUserActive()
     {
         // Arrange
         const string userEmailAddress = "existinguser@email.com";
@@ -335,7 +336,7 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052"};
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
@@ -345,7 +346,7 @@ public class AdminActionTests
     }
     
     [Test]
-    public void DisplaysCorrectUserStatus_WhenUserInactive()
+    public void CreateOrUpdateUserWithLas_DisplaysCorrectUserStatus_WhenUserInactive()
     {
         // Arrange
         const string userEmailAddress = "newuser@email.com";
@@ -353,7 +354,7 @@ public class AdminActionTests
         {
             new UserBuilder("existinguser@email.com").Build()
         };
-        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052"};
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
@@ -371,6 +372,239 @@ public class AdminActionTests
         foreach (var code in custodianCodes)
         {
             mockOutputProvider.Setup(op => op.Output("Code: Local Authority"));
+        }
+
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(confirmation);
+    }
+    
+    [Test]
+    public void CreateOrUpdateUserWithConsortia_ConfirmsCustodianCodesWhenUpdating()
+    {
+        // Arrange
+        const string userEmailAddress = "existinguser@email.com";
+        var users = new List<User>
+        {
+            new UserBuilder("existinguser@email.com").Build()
+        };
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
+        var custodianCodes = new[] { "C_0002", "C_0003" };
+        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
+
+        // Act
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, custodianCodes);
+
+        // Assert
+        mockOutputProvider.Verify(mock => mock.Confirm(It.IsAny<string>()), Times.Once());
+    }
+
+    [Test]
+    public void CreateOrUpdateUserWithConsortia_CreatesNewUser_IfUserNotFoundByDbOperation()
+    {
+        // Arrange
+        const string userEmailAddress = "newuser@email.com";
+        var users = new List<User>
+        {
+            new UserBuilder("existinguser@email.com").Build()
+        };
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
+        var consortiumCodes = new[] { "C_0002" };
+        SetupConfirmCustodianCodes(consortiumCodes, userEmailAddress, true);
+        var consortia = new List<Consortium>
+        {
+            new()
+            {
+                Id = 1,
+                ConsortiumCode = "C_0002"
+            }
+        };
+        mockDatabaseOperation.Setup(mock => mock.GetConsortia(consortiumCodes)).Returns(consortia);
+        
+        // Act
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
+        
+        // Assert
+        mockDatabaseOperation.Verify(
+            mock => mock.CreateUserOrLogError(userEmailAddress, It.IsAny<List<LocalAuthority>>(), consortia), Times.Once());
+    }
+
+    [Test]
+    public void CreateOrUpdateUserWithConsortia_AddsLasToExistingUser_IfUserFoundByDbOperation()
+    {
+        // Arrange
+        var currentConsortia = new List<Consortium>
+        {
+            new()
+            {
+                Id = 2,
+                ConsortiumCode = "C_0002"
+            }
+        };
+        const string userEmailAddress = "existinguser@email.com";
+
+        var users = new List<User>
+        {
+            new UserBuilder("existinguser@email.com").WithConsortia(currentConsortia).Build()
+        };
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
+        
+        var custodianCodes = new[] { "C_0002" };
+        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
+        
+        var consortiaToAdd = new List<Consortium>
+        {
+            new()
+            {
+                Id = 1,
+                ConsortiumCode = "C_0003"
+            }
+        };
+        mockDatabaseOperation.Setup(mock => mock.GetConsortia(custodianCodes)).Returns(consortiaToAdd);
+        
+        // Act
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, custodianCodes);
+        
+        // Assert
+        mockDatabaseOperation.Verify(mock => mock.AddConsortiaToUser(users[0], consortiaToAdd));
+    }
+
+
+    [Test]
+    public void CreateOrUpdateUserWithConsortia_DisplaysErrorMessage_WhenNoLasSpecified_IfUserExists()
+    {
+        // Arrange
+        var userEmailAddress = "existinguser@email.com";
+        var users = new List<User>
+        {
+            new UserBuilder("existinguser@email.com").Build()
+        };
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
+        SetupConfirmCustodianCodes(Array.Empty<string>(), userEmailAddress, true);
+
+        // Act
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, Array.Empty<string>());
+        
+        // Assert
+        mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
+    }
+
+
+    [Test]
+    public void CreateOrUpdateUserWithConsortia_DisplaysInnerExceptionMessage_IfCustodianCode_IsNotFoundInDict()
+    {
+        // Arrange
+        const string userEmailAddress = "existinguser@email.com";
+        var users = new List<User>
+        {
+            new UserBuilder("existinguser@email.com").Build()
+        };
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
+        var listWithCustodianCodeNotInDict = new [] { "C_1111" };
+
+        // Act
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, listWithCustodianCodeNotInDict);
+        
+        // Assert
+        mockOutputProvider.Verify(mock =>
+            mock.Output("The given key 'C_1111' was not present in the dictionary. Process terminated"));
+    }
+
+
+    [Test]
+    public void CreateOrUpdateUserWithConsortia_DoesNotCallDbOperation_IfConfirmKeyNotPressed()
+    {
+        // Arrange
+        const string userEmailAddress = "newuser@email.com";
+        var users = new List<User>
+        {
+            new UserBuilder("existinguser@email.com").Build()
+        };
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
+        var consortiumCodes = new[] { "C_0002" };
+        SetupConfirmConsortiumCodes(consortiumCodes, userEmailAddress, false);
+        var consortiaToAdd = new List<Consortium>
+        {
+            new()
+            {
+                Id = 1,
+                ConsortiumCode = "C_0002"
+            }
+        };
+
+        // Act
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
+
+        // Assert
+        mockOutputProvider.Verify(mock => mock.Output("Process cancelled, no changes were made to the database"));
+        mockDatabaseOperation.Verify(
+            mock => mock.CreateUserOrLogError(userEmailAddress, It.IsAny<List<LocalAuthority>>(), consortiaToAdd), Times.Never());
+
+    }
+
+    [Test]
+    public void CreateOrUpdateUserWithConsortia_AsksForConfirmation()
+    {
+        // Arrange
+        const string userEmailAddress = "newuser@email.com";
+        var users = new List<User>
+        {
+            new UserBuilder("existinguser@email.com").Build()
+        };
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
+        var consortiumCodes = new[] { "C_0002" };
+        
+        // Act
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
+
+        // Assert
+        mockOutputProvider.Verify(mock => mock.Confirm("Please confirm (y/n)"), Times.Once);
+    }
+    
+    [Test]
+    public void CreateOrUpdateUserWithConsortia_DisplaysCorrectUserStatus_WhenUserActive()
+    {
+        // Arrange
+        const string userEmailAddress = "existinguser@email.com";
+        var users = new List<User>
+        {
+            new UserBuilder("existinguser@email.com").Build()
+        };
+   
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
+        var consortiumCodes = new[] { "C_0002" };
+        // Act
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
+        
+        // Assert
+        mockOutputProvider.Verify(mock => mock.Output("User found in database. LAs will be added to their account"), Times.Once());
+    }
+    
+    [Test]
+    public void CreateOrUpdateUserWithConsortia_DisplaysCorrectUserStatus_WhenUserInactive()
+    {
+        // Arrange
+        const string userEmailAddress = "newuser@email.com";
+        var users = new List<User>
+        {
+            new UserBuilder("existinguser@email.com").Build()
+        };
+        mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
+        var consortiumCodes = new[] { "C_0002" };
+        // Act
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
+        
+        // Assert
+        mockOutputProvider.Verify(mock => mock.Output("User not found in database. A new user will be created"), Times.Once());
+    }
+    
+    private void SetupConfirmConsortiumCodes(IEnumerable<string> consortiumCodes, string userEmailAddress, bool confirmation)
+    {
+        mockOutputProvider
+            .Setup(op =>
+                op.Output(
+                    $"You are changing permissions for user {userEmailAddress} for the following consortiums: "));
+        foreach (var code in consortiumCodes)
+        {
+            mockOutputProvider.Setup(op => op.Output("Code: Consortium"));
         }
 
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(confirmation);

--- a/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
@@ -55,7 +55,7 @@ public class AdminActionTests
         SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
 
         // Act
-        underTest.CreateOrUpdateUser(userEmailAddress, custodianCodes);
+        underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
 
         // Assert
         mockOutputProvider.Verify(mock => mock.Confirm(It.IsAny<string>()), Times.Once());
@@ -84,10 +84,11 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(mock => mock.GetLas(custodianCodes)).Returns(las);
         
         // Act
-        underTest.CreateOrUpdateUser(userEmailAddress, custodianCodes);
+        underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
         
         // Assert
-        mockDatabaseOperation.Verify(mock => mock.CreateUserOrLogError(userEmailAddress, las), Times.Once());
+        mockDatabaseOperation.Verify(
+            mock => mock.CreateUserOrLogError(userEmailAddress, las, It.IsAny<List<Consortium>>()), Times.Once());
     }
 
     [Test]
@@ -124,7 +125,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(mock => mock.GetLas(custodianCodes)).Returns(lasToAdd);
         
         // Act
-        underTest.CreateOrUpdateUser(userEmailAddress, custodianCodes);
+        underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
         
         // Assert
         mockDatabaseOperation.Verify(mock => mock.AddLasToUser(users[0], lasToAdd));
@@ -192,7 +193,7 @@ public class AdminActionTests
         SetupConfirmCustodianCodes(Array.Empty<string>(), userEmailAddress, true);
 
         // Act
-        underTest.CreateOrUpdateUser(userEmailAddress, Array.Empty<string>());
+        underTest.CreateOrUpdateUserWithLas(userEmailAddress, Array.Empty<string>());
         
         // Assert
         mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
@@ -242,7 +243,7 @@ public class AdminActionTests
         var listWithCustodianCodeNotInDict = new [] { "1111" };
 
         // Act
-        underTest.CreateOrUpdateUser(userEmailAddress, listWithCustodianCodeNotInDict);
+        underTest.CreateOrUpdateUserWithLas(userEmailAddress, listWithCustodianCodeNotInDict);
         
         // Assert
         mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
@@ -298,11 +299,12 @@ public class AdminActionTests
         };
         
         // Act
-        underTest.CreateOrUpdateUser(userEmailAddress, custodianCodes);
+        underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
         
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("Process cancelled, no changes were made to the database"));
-        mockDatabaseOperation.Verify(mock => mock.CreateUserOrLogError(userEmailAddress, lasToAdd), Times.Never());
+        mockDatabaseOperation.Verify(
+            mock => mock.CreateUserOrLogError(userEmailAddress, lasToAdd, It.IsAny<List<Consortium>>()), Times.Never());
     }
     
     [Test]
@@ -318,7 +320,7 @@ public class AdminActionTests
         var custodianCodes = new[] { "9052"};
         
         // Act
-        underTest.CreateOrUpdateUser(userEmailAddress, custodianCodes);
+        underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
 
         // Assert
         mockOutputProvider.Verify(mock => mock.Confirm("Please confirm (y/n)"), Times.Once);
@@ -336,7 +338,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
         var custodianCodes = new[] { "9052"};
         // Act
-        underTest.CreateOrUpdateUser(userEmailAddress, custodianCodes);
+        underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
         
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("User found in database. LAs will be added to their account"), Times.Once());
@@ -354,7 +356,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthorities()).Returns(users);
         var custodianCodes = new[] { "9052"};
         // Act
-        underTest.CreateOrUpdateUser(userEmailAddress, custodianCodes);
+        underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
         
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("User not found in database. A new user will be created"), Times.Once());

--- a/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
@@ -52,7 +52,7 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052", "2525" };
-        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, custodianCodes);
@@ -72,7 +72,7 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052" };
-        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
         var las = new List<LocalAuthority>
         {
             new()
@@ -112,7 +112,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         var custodianCodes = new[] { "9052" };
-        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         var lasToAdd = new List<LocalAuthority>
         {
@@ -154,7 +154,7 @@ public class AdminActionTests
         // 2372 is in consortium C_0002
         var custodianCodes = new[] { "9052", "2372" };
         var filteredCustodianCodes = new[] { "9052" };
-        SetupConfirmCustodianCodes(filteredCustodianCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         var lasToAdd = new List<LocalAuthority>
         {
@@ -196,7 +196,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         var custodianCodes = new[] { laToRemove.CustodianCode };
-        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
         underTest.RemoveLas(user, custodianCodes);
@@ -234,7 +234,7 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        SetupConfirmCustodianCodes(Array.Empty<string>(), userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, Array.Empty<string>());
@@ -266,7 +266,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         var custodianCodes = new[] { laToRemove.CustodianCode };
-        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
         underTest.RemoveLas(user, custodianCodes);
@@ -306,7 +306,7 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052" };
-        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, false);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
         var lasToAdd = new List<LocalAuthority>
         {
             new()
@@ -334,7 +334,7 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "9052" };
-        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, false);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(false);
         var lasToAdd = new List<LocalAuthority>
         {
             new()
@@ -429,24 +429,6 @@ public class AdminActionTests
         mockOutputProvider.Verify(mock => mock.Output("3805: Adur"), Times.Once());
     }
 
-    private void SetupConfirmCustodianCodes(IEnumerable<string> custodianCodes, string userEmailAddress,
-        bool confirmation)
-    {
-        mockOutputProvider
-            .Setup(op =>
-                op.Output(
-                    $"You are changing permissions for user {userEmailAddress} for the following Local Authorities:"));
-        mockOutputProvider
-            .Setup(op => op.Output("Add the following Local Authorities:"));
-        foreach (var code in custodianCodes) mockOutputProvider.Setup(op => op.Output("Code: Local Authority"));
-        mockOutputProvider
-            .Setup(op =>
-                op.Output("Ignore the following Local Authorities already in owned Consortia:"));
-        mockOutputProvider.Setup(op => op.Output("(None)"));
-
-        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(confirmation);
-    }
-
     [Test]
     public void CreateOrUpdateUserWithConsortia_ConfirmsCustodianCodesWhenUpdating()
     {
@@ -458,7 +440,7 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var custodianCodes = new[] { "C_0002", "C_0003" };
-        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, custodianCodes);
@@ -478,7 +460,7 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var consortiumCodes = new[] { "C_0002" };
-        SetupConfirmCustodianCodes(consortiumCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
         var consortia = new List<Consortium>
         {
             new()
@@ -519,7 +501,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         var custodianCodes = new[] { "C_0003" };
-        SetupConfirmCustodianCodes(custodianCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         var consortiaToAdd = new List<Consortium>
         {
@@ -549,7 +531,7 @@ public class AdminActionTests
             new UserBuilder("existinguser@email.com").Build()
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
-        SetupConfirmCustodianCodes(Array.Empty<string>(), userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, Array.Empty<string>());
@@ -591,7 +573,7 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var consortiumCodes = new[] { "C_0002" };
-        SetupConfirmConsortiumCodes(consortiumCodes, userEmailAddress, false);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(false);
         var consortiaToAdd = new List<Consortium>
         {
             new()
@@ -737,7 +719,7 @@ public class AdminActionTests
 
         var consortiumCodes = new[] { "C_0002" };
         var custodianCodesToRemove = new[] { "2372" };
-        SetupConfirmCustodianCodes(consortiumCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         var consortiaToAdd = new List<Consortium>
         {
@@ -780,7 +762,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         var custodianCodes = new[] { consortiumToRemove.ConsortiumCode };
-        SetupConfirmConsortiumCodes(custodianCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
         underTest.RemoveConsortia(user, custodianCodes);
@@ -813,7 +795,7 @@ public class AdminActionTests
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
         var consortiumCodes = new[] { consortiumToRemove.ConsortiumCode };
-        SetupConfirmConsortiumCodes(consortiumCodes, userEmailAddress, true);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
         underTest.RemoveConsortia(user, consortiumCodes);
@@ -835,24 +817,12 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
         var consortiumCodes = new[] { "C_0002" };
-        SetupConfirmConsortiumCodes(consortiumCodes, userEmailAddress, false);
+        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
         underTest.RemoveConsortia(null, consortiumCodes);
 
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("User not found"));
-    }
-
-    private void SetupConfirmConsortiumCodes(IEnumerable<string> consortiumCodes, string userEmailAddress,
-        bool confirmation)
-    {
-        mockOutputProvider
-            .Setup(op =>
-                op.Output(
-                    $"You are changing permissions for user {userEmailAddress} for the following consortiums: "));
-        foreach (var code in consortiumCodes) mockOutputProvider.Setup(op => op.Output("Code: Consortium"));
-
-        mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(confirmation);
     }
 }

--- a/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/AdminActionTests.cs
@@ -500,7 +500,7 @@ public class AdminActionTests
         };
         mockDatabaseOperation.Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia()).Returns(users);
 
-        var custodianCodes = new[] { "C_0003" };
+        var consortiumCodes = new[] { "C_0003" };
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         var consortiaToAdd = new List<Consortium>
@@ -511,10 +511,10 @@ public class AdminActionTests
                 ConsortiumCode = "C_0003"
             }
         };
-        mockDatabaseOperation.Setup(mock => mock.GetConsortia(custodianCodes)).Returns(consortiaToAdd);
+        mockDatabaseOperation.Setup(mock => mock.GetConsortia(consortiumCodes)).Returns(consortiaToAdd);
 
         // Act
-        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, custodianCodes);
+        underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
 
         // Assert
         mockDatabaseOperation.Verify(mock => mock.AddConsortiaToUser(users[0], consortiaToAdd));

--- a/HerPortal.UnitTests/ManagementShell/CommandHandlerTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/CommandHandlerTests.cs
@@ -8,18 +8,19 @@ using Tests.Builders;
 
 namespace Tests.ManagementShell;
 
-public class AdminActionTests
+public class CommandHandlerTests
 {
     private Mock<IDatabaseOperation> mockDatabaseOperation;
     private Mock<IOutputProvider> mockOutputProvider;
-    private AdminAction underTest;
+    private CommandHandler underTest;
 
     [SetUp]
     public void Setup()
     {
         mockOutputProvider = new Mock<IOutputProvider>();
         mockDatabaseOperation = new Mock<IDatabaseOperation>();
-        underTest = new AdminAction(mockDatabaseOperation.Object, mockOutputProvider.Object);
+        var adminAction = new AdminAction(mockDatabaseOperation.Object);
+        underTest = new CommandHandler(adminAction, mockOutputProvider.Object);
     }
 
     [Test]
@@ -200,7 +201,7 @@ public class AdminActionTests
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
-        underTest.RemoveLas(user, custodianCodes);
+        underTest.TryRemoveLas(user, custodianCodes);
 
         // Assert
         mockDatabaseOperation.Verify(mock => mock.RemoveLasFromUser(user, new List<LocalAuthority> { laToRemove }),
@@ -241,7 +242,7 @@ public class AdminActionTests
         underTest.CreateOrUpdateUserWithLas(userEmailAddress, Array.Empty<string>());
 
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
+        mockOutputProvider.Verify(mock => mock.Output("Please specify custodian codes to add to user"));
     }
 
     [Test]
@@ -270,10 +271,10 @@ public class AdminActionTests
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
-        underTest.RemoveLas(user, custodianCodes);
+        underTest.TryRemoveLas(user, custodianCodes);
 
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
+        mockOutputProvider.Verify(mock => mock.Output("Could not remove LAs from user: Could not find LAs attached to existinguser@email.com for the following codes: 9052. Please check your inputs and try again."));
     }
 
     [Test]
@@ -318,7 +319,7 @@ public class AdminActionTests
         };
 
         // Act
-        underTest.RemoveLas(null, custodianCodes);
+        underTest.TryRemoveLas(null, custodianCodes);
 
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("User not found"));
@@ -541,7 +542,7 @@ public class AdminActionTests
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, Array.Empty<string>());
 
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output(It.IsAny<string>()));
+        mockOutputProvider.Verify(mock => mock.Output("Please specify consortium codes to add to user"));
     }
 
 
@@ -769,7 +770,7 @@ public class AdminActionTests
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
-        underTest.RemoveConsortia(user, custodianCodes);
+        underTest.TryRemoveConsortia(user, custodianCodes);
 
         // Assert
         mockDatabaseOperation.Verify(mock => mock.RemoveConsortiaFromUser(user, new List<Consortium> { consortiumToRemove }),
@@ -802,12 +803,12 @@ public class AdminActionTests
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
-        underTest.RemoveConsortia(user, consortiumCodes);
+        underTest.TryRemoveConsortia(user, consortiumCodes);
 
         // Assert
         mockOutputProvider.Verify(mock =>
             mock.Output(
-                "Could not find Consortia attached to existinguser@email.com for the following codes: C_0002. Please check your inputs and try again."));
+                "Could not remove Consortia from user: Could not find Consortia attached to existinguser@email.com for the following codes: C_0002. Please check your inputs and try again."));
     }
 
     [Test]
@@ -824,7 +825,7 @@ public class AdminActionTests
         mockOutputProvider.Setup(op => op.Confirm("Please confirm (y/n)")).Returns(true);
 
         // Act
-        underTest.RemoveConsortia(null, consortiumCodes);
+        underTest.TryRemoveConsortia(null, consortiumCodes);
 
         // Assert
         mockOutputProvider.Verify(mock => mock.Output("User not found"));

--- a/HerPortal.UnitTests/ManagementShell/CommandHandlerTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/CommandHandlerTests.cs
@@ -274,7 +274,9 @@ public class CommandHandlerTests
         underTest.TryRemoveLas(user, custodianCodes);
 
         // Assert
-        mockOutputProvider.Verify(mock => mock.Output("Could not remove LAs from user: Could not find LAs attached to existinguser@email.com for the following codes: 9052. Please check your inputs and try again."));
+        mockOutputProvider.Verify(mock =>
+            mock.Output(
+                "Could not remove LAs from user: Could not find LAs attached to existinguser@email.com for the following codes: 9052. Please check your inputs and try again."));
     }
 
     [Test]
@@ -741,9 +743,10 @@ public class CommandHandlerTests
         underTest.CreateOrUpdateUserWithConsortia(userEmailAddress, consortiumCodes);
 
         // Assert
-        mockDatabaseOperation.Verify(mock => mock.AddConsortiaAndRemoveLasFromUser(users[0], consortiaToAdd, currentLa));
+        mockDatabaseOperation.Verify(mock =>
+            mock.AddConsortiaAndRemoveLasFromUser(users[0], consortiaToAdd, currentLa));
     }
-    
+
     [Test]
     public void RemoveConsortia_RemovesLasFromExistingUser_IfUserFoundByDbOperation()
     {
@@ -773,7 +776,8 @@ public class CommandHandlerTests
         underTest.TryRemoveConsortia(user, custodianCodes);
 
         // Assert
-        mockDatabaseOperation.Verify(mock => mock.RemoveConsortiaFromUser(user, new List<Consortium> { consortiumToRemove }),
+        mockDatabaseOperation.Verify(
+            mock => mock.RemoveConsortiaFromUser(user, new List<Consortium> { consortiumToRemove }),
             Times.Once());
     }
 


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1085)

# Description

adds two new CLI commands:
- AddConsortia, creates a user if needed and assigns them the given consortium codes
- RemoveConsortia, removes consortia from a user

the commands have the additional logic to keep the relation between LAs and Consortia consistent:
- when adding LAs to a user, if the user owns any Consortia that contains the LA to be added, ignore it
- when adding a Consortium to a user, if the user owns any LA in that Consortium, remove it

unit tests have been added to verify this behaviour

Swiki has been updated to reflect the new command

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the main HUG2 repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta)

# Suggested QA

| Action | Expected Result |
| ---- | ---- |
| Add a Consortium to a user | New row added in ConsortiumUser |
| Remove a Consortium from a user | Row removed from ConsortiumUser |
| Add a Consortium to a user that they're already in | Error message & no change |
| Add a Consortium to a user that does not exist in the database | Error message & no change |
| Add a Consortium to a user that does not exist in the code | Error message & no change |
| Remove a Consortium from a user that they're not in | Error message & no change |
| Remove a Consortium from a user that does not exist in the database | Error message & no change |
| Remove a Consortium from a user that does not exist in the code | Error message & no change |
| Add an LA to a user that is in a Consortium they own | Warning message & the LA is not added |
| Add a Consortium to a user which contains an LA they own | Warning message & the LA is removed |

# Screenshots

## Add Consortia
![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta/assets/108681823/725b2311-8beb-48cb-8f8a-27bd182a8cac)

## Remove Consortia
![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta/assets/108681823/a0923fa6-7f11-44c3-ba78-dd1bc34984b8)

## Removing LA in Consortia
![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta/assets/108681823/7139a697-9e77-419f-a347-1b3b63b0e689)

## Ignoring LA in Consortia
![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta/assets/108681823/d064d9c2-795c-4bbc-b0ad-a536cb64d10c)
