### PR TITLE
PC-1086 Migrate historic data for consortium admins

### DIFF
--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -46,6 +46,11 @@ public class AdminAction
             .ToList();
     }
 
+    public IEnumerable<string> GetCustodianCodesInConsortia(IEnumerable<string> consortiumCodes)
+    {
+        return consortiumCodes.SelectMany(consortiumCode => consortiumCodeToCustodianCodesDict[consortiumCode]);
+    }
+
     public UserAccountStatus GetUserStatus(User? userOrNull)
     {
         return userOrNull == null ? UserAccountStatus.New : UserAccountStatus.Active;
@@ -128,7 +133,7 @@ public class AdminAction
     public void FixUserOwnedConsortia(User user)
     {
         var consortiumCodesToAdd = GetConsortiumCodesUserShouldOwn(user).ToList();
-        var custodianCodesToRemove = GetOwnedCustodianCodesInConsortia(user, consortiumCodesToAdd);
+        var custodianCodesToRemove = GetCustodianCodesInConsortia(consortiumCodesToAdd).ToList();
 
         var consortiaToAdd = dbOperation.GetConsortia(consortiumCodesToAdd);
         var lasToRemove = dbOperation.GetLas(custodianCodesToRemove);

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -125,7 +125,7 @@ public class AdminAction
         return dbOperation.GetUsersWithLocalAuthoritiesAndConsortia();
     }
 
-    public void MigrateAdmin(User user)
+    public void FixUserOwnedConsortia(User user)
     {
         var consortiumCodesToAdd = GetConsortiumCodesUserShouldOwn(user).ToList();
         var custodianCodesToRemove = GetOwnedCustodianCodesInConsortia(user, consortiumCodesToAdd);

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -132,7 +132,7 @@ public class AdminAction
 
         var consortiaToAdd = dbOperation.GetConsortia(consortiumCodesToAdd);
         var lasToRemove = dbOperation.GetLas(custodianCodesToRemove);
-        
+
         dbOperation.AddConsortiaAndRemoveLasFromUser(user, consortiaToAdd, lasToRemove);
     }
 

--- a/HerPortal.ManagementShell/AdminAction.cs
+++ b/HerPortal.ManagementShell/AdminAction.cs
@@ -117,4 +117,9 @@ public partial class AdminAction
 
         dbOperation.RemoveConsortiaFromUser(user, consortiaToRemove);
     }
+
+    public void MigrateAdmins()
+    {
+        // TODO: implement
+    }
 }

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -165,8 +165,17 @@ public class CommandHandler
 
             var confirmation = outputProvider.Confirm("Okay to proceed? (Y/N)");
 
-            if (confirmation) adminAction.MigrateAdmin(user);
+            if (confirmation)
+            {
+                adminAction.MigrateAdmin(user);
+            }
+            else
+            {
+                outputProvider.Output("No changes made.");
+            }
         }
+        
+        outputProvider.Output("Migration complete.");
     }
 
     private void OutputCouldNotFindAuthorityException(string wrapperMessage,

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -159,7 +159,7 @@ public class CommandHandler
                 consortiumCode => consortiumCodeToConsortiumNameDict[consortiumCode]);
 
             var custodianCodesToRemove =
-                adminAction.GetOwnedCustodianCodesInConsortia(user, consortiumCodesUserShouldOwn);
+                adminAction.GetCustodianCodesInConsortia(consortiumCodesUserShouldOwn).ToList();
             outputProvider.Output("To make this user a Consortium Admin, the following LAs will be removed:");
             PrintCodes(custodianCodesToRemove, custodianCode => custodianCodeToLaNameDict[custodianCode]);
 

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -166,15 +166,11 @@ public class CommandHandler
             var confirmation = outputProvider.Confirm("Okay to proceed? (Y/N)");
 
             if (confirmation)
-            {
                 adminAction.MigrateAdmin(user);
-            }
             else
-            {
                 outputProvider.Output("No changes made.");
-            }
         }
-        
+
         outputProvider.Output("Migration complete.");
     }
 

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -142,8 +142,8 @@ public class CommandHandler
     {
         outputProvider.Output("!!! User Migration Script !!!");
         outputProvider.Output("This script will ensure the validity of the LA / Consortium relationship for users.");
-        outputProvider.Output("If a user owns all LAs in a Consortium, they will be made a Consortium Admin.");
-        outputProvider.Output("If a user owns an LA in an owned Consortium, they will be removed.");
+        outputProvider.Output(
+            "If a user owns all LAs in a Consortium, they will be made a Consortium Admin and the LAs will be removed.");
 
         var users = adminAction.GetUsers();
 

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -152,7 +152,11 @@ public class CommandHandler
             outputProvider.Output($"Processing user {user.EmailAddress}...");
             var consortiumCodesUserShouldOwn = adminAction.GetConsortiumCodesUserShouldOwn(user).ToList();
 
-            if (consortiumCodesUserShouldOwn.Count == 0) continue;
+            if (consortiumCodesUserShouldOwn.Count == 0)
+            {
+                outputProvider.Output("No changes needed.");
+                continue;
+            }
 
             outputProvider.Output("This user should own the following Consortia:");
             PrintCodes(consortiumCodesUserShouldOwn,

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -87,7 +87,8 @@ public class CommandHandler
         }
         catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            OutputCouldNotFindAuthorityException($"Could not remove Custodian Codes from {user.EmailAddress}.", couldNotFindAuthorityException);
+            OutputCouldNotFindAuthorityException($"Could not remove Custodian Codes from {user.EmailAddress}.",
+                couldNotFindAuthorityException);
         }
     }
 
@@ -132,7 +133,8 @@ public class CommandHandler
         }
         catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            OutputCouldNotFindAuthorityException($"Could not remove Consortium Codes from {user.EmailAddress}.", couldNotFindAuthorityException);
+            OutputCouldNotFindAuthorityException($"Could not remove Consortium Codes from {user.EmailAddress}.",
+                couldNotFindAuthorityException);
         }
     }
 
@@ -144,16 +146,17 @@ public class CommandHandler
         outputProvider.Output("If a user owns an LA in an owned Consortium, they will be removed.");
 
         var users = adminAction.GetUsers();
-        
+
         foreach (var user in users)
         {
             outputProvider.Output($"Processing user {user.EmailAddress}...");
             var consortiumCodesUserShouldOwn = adminAction.GetConsortiumCodesUserShouldOwn(user).ToList();
 
             if (consortiumCodesUserShouldOwn.Count == 0) continue;
-            
+
             outputProvider.Output("This user should own the following Consortia:");
-            PrintCodes(consortiumCodesUserShouldOwn, consortiumCode => consortiumCodeToConsortiumNameDict[consortiumCode]);
+            PrintCodes(consortiumCodesUserShouldOwn,
+                consortiumCode => consortiumCodeToConsortiumNameDict[consortiumCode]);
 
             var custodianCodesToRemove =
                 adminAction.GetOwnedCustodianCodesInConsortia(user, consortiumCodesUserShouldOwn);
@@ -161,12 +164,13 @@ public class CommandHandler
             PrintCodes(custodianCodesToRemove, custodianCode => custodianCodeToLaNameDict[custodianCode]);
 
             var confirmation = outputProvider.Confirm("Okay to proceed? (Y/N)");
-                
+
             if (confirmation) adminAction.MigrateAdmin(user);
         }
     }
 
-    private void OutputCouldNotFindAuthorityException(string wrapperMessage, CouldNotFindAuthorityException couldNotFindAuthorityException)
+    private void OutputCouldNotFindAuthorityException(string wrapperMessage,
+        CouldNotFindAuthorityException couldNotFindAuthorityException)
     {
         outputProvider.Output("!!! Error occured during operation !!!");
         outputProvider.Output(wrapperMessage);
@@ -300,7 +304,8 @@ public class CommandHandler
         }
         catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            OutputCouldNotFindAuthorityException($"Could not create user {userEmailAddress}.", couldNotFindAuthorityException);
+            OutputCouldNotFindAuthorityException($"Could not create user {userEmailAddress}.",
+                couldNotFindAuthorityException);
         }
     }
 
@@ -324,7 +329,8 @@ public class CommandHandler
         }
         catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            OutputCouldNotFindAuthorityException($"Could not add Custodian Codes to {user.EmailAddress}.", couldNotFindAuthorityException);
+            OutputCouldNotFindAuthorityException($"Could not add Custodian Codes to {user.EmailAddress}.",
+                couldNotFindAuthorityException);
         }
     }
 
@@ -348,7 +354,8 @@ public class CommandHandler
         }
         catch (CouldNotFindAuthorityException couldNotFindAuthorityException)
         {
-            OutputCouldNotFindAuthorityException($"Could not add Consortium Codes to {user.EmailAddress}.", couldNotFindAuthorityException);
+            OutputCouldNotFindAuthorityException($"Could not add Consortium Codes to {user.EmailAddress}.",
+                couldNotFindAuthorityException);
         }
     }
 

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -136,6 +136,11 @@ public class CommandHandler
         }
     }
 
+    public void MigrateAdmins()
+    {
+        adminAction.MigrateAdmins();
+    }
+
     private void OutputCouldNotFindAuthorityException(string wrapperMessage, CouldNotFindAuthorityException couldNotFindAuthorityException)
     {
         outputProvider.Output("!!! Error occured during operation !!!");

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -164,7 +164,7 @@ public class CommandHandler
 
             var custodianCodesToRemove =
                 adminAction.GetCustodianCodesInConsortia(consortiumCodesUserShouldOwn).ToList();
-            outputProvider.Output("To make this user a Consortium Admin, the following LAs will be removed:");
+            outputProvider.Output("To make this user a Consortium Admin, the following LAs will be removed from the user:");
             PrintCodes(custodianCodesToRemove, custodianCode => custodianCodeToLaNameDict[custodianCode]);
 
             var confirmation = outputProvider.Confirm("Okay to proceed? (Y/N)");

--- a/HerPortal.ManagementShell/CommandHandler.cs
+++ b/HerPortal.ManagementShell/CommandHandler.cs
@@ -138,7 +138,7 @@ public class CommandHandler
         }
     }
 
-    public void MigrateAdmins()
+    public void FixAllUserOwnedConsortia()
     {
         outputProvider.Output("!!! User Migration Script !!!");
         outputProvider.Output("This script will ensure the validity of the LA / Consortium relationship for users.");
@@ -166,7 +166,7 @@ public class CommandHandler
             var confirmation = outputProvider.Confirm("Okay to proceed? (Y/N)");
 
             if (confirmation)
-                adminAction.MigrateAdmin(user);
+                adminAction.FixUserOwnedConsortia(user);
             else
                 outputProvider.Output("No changes made.");
         }

--- a/HerPortal.ManagementShell/Program.cs
+++ b/HerPortal.ManagementShell/Program.cs
@@ -66,8 +66,8 @@ public static class Program
             case Subcommand.RemoveConsortia:
                 commandHandler.TryRemoveConsortia(commandHandler.GetUser(userEmailAddress), codes);
                 break;
-            case Subcommand.MigrateUsers:
-                commandHandler.MigrateAdmins();
+            case Subcommand.FixAllUserOwnedConsortia:
+                commandHandler.FixAllUserOwnedConsortia();
                 break;
             default:
                 outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");
@@ -82,6 +82,6 @@ public static class Program
         RemoveUser,
         AddConsortia,
         RemoveConsortia,
-        MigrateUsers
+        FixAllUserOwnedConsortia
     }
 }

--- a/HerPortal.ManagementShell/Program.cs
+++ b/HerPortal.ManagementShell/Program.cs
@@ -28,8 +28,18 @@ public static class Program
         try
         {
             command = Enum.Parse<Subcommand>(args[0], true);
-            userEmailAddress = args[1];
-            codes = args.Skip(2).ToArray();
+            if (new List<Subcommand>
+                {
+                    Subcommand.AddLas,
+                    Subcommand.AddConsortia,
+                    Subcommand.RemoveLas,
+                    Subcommand.RemoveConsortia,
+                    Subcommand.RemoveUser
+                }.Contains(command))
+            {
+                userEmailAddress = args[1];
+                codes = args.Skip(2).ToArray();
+            }
         }
         catch (Exception)
         {
@@ -56,6 +66,9 @@ public static class Program
             case Subcommand.RemoveConsortia:
                 commandHandler.TryRemoveConsortia(commandHandler.GetUser(userEmailAddress), codes);
                 break;
+            case Subcommand.MigrateUsers:
+                commandHandler.MigrateAdmins();
+                break;
             default:
                 outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");
                 return;
@@ -68,6 +81,7 @@ public static class Program
         RemoveLas,
         RemoveUser,
         AddConsortia,
-        RemoveConsortia
+        RemoveConsortia,
+        MigrateUsers
     }
 }

--- a/HerPortal.UnitTests/ManagementShell/FixAllUserOwnedConsortiaCommandTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/FixAllUserOwnedConsortiaCommandTests.cs
@@ -205,6 +205,7 @@ public class FixAllUserOwnedConsortiaCommandTests
 
     private IEnumerable<(string, List<string>)> GetExampleConsortiumCodesWithCustodianCodes()
     {
+        // both these Consortia have two LAs
         yield return ("C_0008", new List<string> { "660", "665" });
         yield return ("C_0010", new List<string> { "840", "835" });
     }

--- a/HerPortal.UnitTests/ManagementShell/FixAllUserOwnedConsortiaCommandTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/FixAllUserOwnedConsortiaCommandTests.cs
@@ -8,7 +8,7 @@ using Tests.Builders;
 
 namespace Tests.ManagementShell;
 
-public class MigrateAdminsCommandTests
+public class FixAllUserOwnedConsortiaCommandTests
 {
     private Mock<IDatabaseOperation> mockDatabaseOperation;
     private Mock<IOutputProvider> mockOutputProvider;
@@ -28,7 +28,7 @@ public class MigrateAdminsCommandTests
     // - Cheshire West and Chester 665
 
     [Test]
-    public void MigrateAdmins_IfOwnsAllLas_RemovesLasAndAddConsortia()
+    public void FixAllUserOwnedConsortia_IfOwnsAllLas_RemovesLasAndAddConsortia()
     {
         // Arrange
         var (user, expectedLasToRemove, expectedConsortiaToAdd) = SetupUser(new UserTestSetup
@@ -52,7 +52,7 @@ public class MigrateAdminsCommandTests
     }
 
     [Test]
-    public void MigrateAdmins_IfOwnsNotEnoughLas_DoesNothing()
+    public void FixAllUserOwnedConsortia_IfOwnsNotEnoughLas_DoesNothing()
     {
         // Arrange
         var (user, _, _) = SetupUser(new UserTestSetup
@@ -74,7 +74,7 @@ public class MigrateAdminsCommandTests
     }
 
     [Test]
-    public void MigrateAdmins_IfOwnsAllLasInTwoConsortia_AddsBoth()
+    public void FixAllUserOwnedConsortia_IfOwnsAllLasInTwoConsortia_AddsBoth()
     {
         // Arrange
         var (user, expectedLasToRemove, expectedConsortiaToAdd) = SetupUser(new UserTestSetup
@@ -98,7 +98,7 @@ public class MigrateAdminsCommandTests
     }
 
     [Test]
-    public void MigrateAdmins_IfOwnsAllInAConsortiaButNotEnoughInAnother_AddsOneConsortia()
+    public void FixAllUserOwnedConsortia_IfOwnsAllInAConsortiaButNotEnoughInAnother_AddsOneConsortia()
     {
         // Arrange
         var (user, expectedLasToRemove, expectedConsortiaToAdd) = SetupUser(new UserTestSetup
@@ -122,7 +122,7 @@ public class MigrateAdminsCommandTests
     }
 
     [Test]
-    public void MigrateAdmins_IfOwnsConsortia_DoesNothing()
+    public void FixAllUserOwnedConsortia_IfOwnsConsortia_DoesNothing()
     {
         // Arrange
         var (user, _, _) = SetupUser(new UserTestSetup

--- a/HerPortal.UnitTests/ManagementShell/FixAllUserOwnedConsortiaCommandTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/FixAllUserOwnedConsortiaCommandTests.cs
@@ -80,7 +80,7 @@ public class FixAllUserOwnedConsortiaCommandTests
         var (user, expectedLasToRemove, expectedConsortiaToAdd) = SetupUser(new UserTestSetup
         {
             UserCustodianCodes = new List<string> { "660", "665", "835", "840" },
-            ExpectedCustodianCodesToRemove = new List<string> { "660", "665", "835", "840" },
+            ExpectedCustodianCodesToRemove = new List<string> { "660", "665", "840", "835" },
             ExpectedConsortiumCodesToAdd = new List<string> { "C_0008", "C_0010" }
         });
 
@@ -89,7 +89,7 @@ public class FixAllUserOwnedConsortiaCommandTests
 
         // Assert
         mockDatabaseOperation.Verify(db => db.GetUsersWithLocalAuthoritiesAndConsortia());
-        mockDatabaseOperation.Verify(db => db.GetLas(new List<string> { "660", "665", "835", "840" }));
+        mockDatabaseOperation.Verify(db => db.GetLas(new List<string> { "660", "665", "840", "835" }));
         mockDatabaseOperation.Verify(db => db.GetConsortia(new List<string> { "C_0008", "C_0010" }));
         mockDatabaseOperation.Verify(
             db => db.AddConsortiaAndRemoveLasFromUser(user, expectedConsortiaToAdd, expectedLasToRemove));

--- a/HerPortal.UnitTests/ManagementShell/MigrateAdminsCommandTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/MigrateAdminsCommandTests.cs
@@ -127,7 +127,7 @@ public class MigrateAdminsCommandTests
         // Arrange
         var (user, _, _) = SetupUser(new UserTestSetup
         {
-            UserConsortiumCodes = new List<string> { "C_0008" },
+            UserConsortiumCodes = new List<string> { "C_0008" }
         });
 
         // Act
@@ -187,7 +187,7 @@ public class MigrateAdminsCommandTests
 
         return (user, expectedLasToRemove, expectedConsortiaToAdd);
     }
-    
+
     private struct UserTestSetup
     {
         public IEnumerable<string> UserCustodianCodes = new List<string>();

--- a/HerPortal.UnitTests/ManagementShell/MigrateAdminsCommandTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/MigrateAdminsCommandTests.cs
@@ -143,7 +143,8 @@ public class MigrateAdminsCommandTests
     }
 
     private (User, List<LocalAuthority>, List<Consortium>) SetupUser(IEnumerable<string> custodianCodes,
-        IReadOnlyCollection<string> consortiumCodes, IReadOnlyCollection<string> expectedCustodianCodesToRemove, IReadOnlyCollection<string> expectedConsortiumCodes)
+        IReadOnlyCollection<string> consortiumCodes, IReadOnlyCollection<string> expectedCustodianCodesToRemove,
+        IReadOnlyCollection<string> expectedConsortiumCodes)
     {
         var localAuthorities = custodianCodes
             .Select((custodianCode, i) => new LocalAuthority

--- a/HerPortal.UnitTests/ManagementShell/MigrateAdminsCommandTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/MigrateAdminsCommandTests.cs
@@ -39,7 +39,7 @@ public class MigrateAdminsCommandTests
         });
 
         // Act
-        underTest.MigrateAdmins();
+        underTest.FixAllUserOwnedConsortia();
 
         // Assert
         mockDatabaseOperation.Verify(db => db.GetUsersWithLocalAuthoritiesAndConsortia());
@@ -61,7 +61,7 @@ public class MigrateAdminsCommandTests
         });
 
         // Act
-        underTest.MigrateAdmins();
+        underTest.FixAllUserOwnedConsortia();
 
         // Assert
         mockDatabaseOperation.Verify(db => db.GetUsersWithLocalAuthoritiesAndConsortia());
@@ -85,7 +85,7 @@ public class MigrateAdminsCommandTests
         });
 
         // Act
-        underTest.MigrateAdmins();
+        underTest.FixAllUserOwnedConsortia();
 
         // Assert
         mockDatabaseOperation.Verify(db => db.GetUsersWithLocalAuthoritiesAndConsortia());
@@ -109,7 +109,7 @@ public class MigrateAdminsCommandTests
         });
 
         // Act
-        underTest.MigrateAdmins();
+        underTest.FixAllUserOwnedConsortia();
 
         // Assert
         mockDatabaseOperation.Verify(db => db.GetUsersWithLocalAuthoritiesAndConsortia());
@@ -131,7 +131,7 @@ public class MigrateAdminsCommandTests
         });
 
         // Act
-        underTest.MigrateAdmins();
+        underTest.FixAllUserOwnedConsortia();
 
         // Assert
         mockDatabaseOperation.Verify(db => db.GetUsersWithLocalAuthoritiesAndConsortia());

--- a/HerPortal.UnitTests/ManagementShell/MigrateAdminsCommandTests.cs
+++ b/HerPortal.UnitTests/ManagementShell/MigrateAdminsCommandTests.cs
@@ -1,0 +1,184 @@
+using System.Collections.Generic;
+using System.Linq;
+using HerPortal.BusinessLogic.Models;
+using HerPortal.ManagementShell;
+using Moq;
+using NUnit.Framework;
+using Tests.Builders;
+
+namespace Tests.ManagementShell;
+
+public class MigrateAdminsCommandTests
+{
+    private Mock<IDatabaseOperation> mockDatabaseOperation;
+    private Mock<IOutputProvider> mockOutputProvider;
+    private CommandHandler underTest;
+
+    [SetUp]
+    public void Setup()
+    {
+        mockOutputProvider = new Mock<IOutputProvider>();
+        mockDatabaseOperation = new Mock<IDatabaseOperation>();
+        var adminAction = new AdminAction(mockDatabaseOperation.Object);
+        underTest = new CommandHandler(adminAction, mockOutputProvider.Object);
+    }
+
+    // Cheshire East C_0008 contains only two LAs:
+    // - Cheshire East 660
+    // - Cheshire West and Chester 665
+
+    [Test]
+    public void MigrateAdmins_IfOwnsAllLas_RemovesLasAndAddConsortia()
+    {
+        // Arrange
+        var (user, localAuthorities, expectedConsortia) = SetupUser(
+            new List<string> { "660", "665" },
+            new List<string>(),
+            new List<string> { "C_0008" });
+
+        // Act
+        underTest.MigrateAdmins();
+
+        // Assert
+        mockDatabaseOperation.Verify(
+            db => db.AddConsortiaAndRemoveLasFromUser(user, expectedConsortia, localAuthorities));
+    }
+
+    [Test]
+    public void MigrateAdmins_IfOwnsNotEnoughLas_DoesNothing()
+    {
+        // Arrange
+        var (user, _, _) = SetupUser(
+            new List<string> { "660" },
+            new List<string>(),
+            new List<string> { "C_0008" });
+
+        // Act
+        underTest.MigrateAdmins();
+
+        // Assert
+        mockDatabaseOperation.Verify(
+            db => db.AddConsortiaAndRemoveLasFromUser(
+                user, It.IsAny<List<Consortium>>(), It.IsAny<List<LocalAuthority>>()),
+            Times.Never);
+
+        mockDatabaseOperation.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public void MigrateAdmins_IfOwnsAllLasInTwoConsortia_AddsBoth()
+    {
+        // Arrange
+        var (user, localAuthorities, expectedConsortia) = SetupUser(
+            new List<string> { "660", "665", "835", "840" },
+            new List<string>(),
+            new List<string> { "C_0008", "C_0010" });
+
+        // Act
+        underTest.MigrateAdmins();
+
+        // Assert
+        mockDatabaseOperation.Verify(
+            db => db.AddConsortiaAndRemoveLasFromUser(user, expectedConsortia, localAuthorities));
+
+        mockDatabaseOperation.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public void MigrateAdmins_IfOwnsAllInAConsortiaButNotEnoughInAnother_AddsOneConsortia()
+    {
+        // Arrange
+        var (user, localAuthorities, expectedConsortia) = SetupUser(
+            new List<string> { "660", "665", "835" },
+            new List<string>(),
+            new List<string> { "C_0008" });
+
+        // Act
+        underTest.MigrateAdmins();
+
+        // Assert
+        mockDatabaseOperation.Verify(
+            db => db.AddConsortiaAndRemoveLasFromUser(user, expectedConsortia, localAuthorities));
+
+        mockDatabaseOperation.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public void MigrateAdmins_IfOwnsConsortia_DoesNothing()
+    {
+        // Arrange
+        var (user, _, _) = SetupUser(
+            new List<string>(),
+            new List<string> { "C_0008" },
+            new List<string> { "C_0008" });
+
+        // Act
+        underTest.MigrateAdmins();
+
+        // Assert
+        mockDatabaseOperation.Verify(
+            db => db.AddConsortiaAndRemoveLasFromUser(
+                user, It.IsAny<List<Consortium>>(), It.IsAny<List<LocalAuthority>>()),
+            Times.Never);
+
+        mockDatabaseOperation.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public void MigrateAdmins_IfOwnsAllLasAndAlreadyOwnsConsortia_RemovesLasButLeavesConsortia()
+    {
+        // Arrange
+        var (user, localAuthorities, _) = SetupUser(
+            new List<string> { "835", "840" },
+            new List<string> { "C_0008" },
+            new List<string> { "C_0008" });
+
+        // Act
+        underTest.MigrateAdmins();
+
+        // Assert
+        mockDatabaseOperation.Verify(
+            db => db.RemoveLasFromUser(user, localAuthorities));
+
+        mockDatabaseOperation.VerifyNoOtherCalls();
+    }
+
+    private (User, List<LocalAuthority>, List<Consortium>) SetupUser(IEnumerable<string> custodianCodes,
+        IReadOnlyCollection<string> consortiumCodes, IReadOnlyCollection<string> expectedConsortiumCodes)
+    {
+        var localAuthorities = custodianCodes
+            .Select((custodianCode, i) => new LocalAuthority
+            {
+                Id = i,
+                CustodianCode = custodianCode
+            })
+            .ToList();
+        var consortia = consortiumCodes
+            .Select((consortiumCode, i) => new Consortium
+            {
+                Id = i,
+                ConsortiumCode = consortiumCode
+            })
+            .ToList();
+        var expectedConsortia = expectedConsortiumCodes
+            .Select((consortiumCode, i) => new Consortium
+            {
+                Id = i + consortiumCodes.Count,
+                ConsortiumCode = consortiumCode
+            })
+            .ToList();
+
+        var user = new UserBuilder("user@example.com")
+            .WithLocalAuthorities(localAuthorities)
+            .WithConsortia(consortia)
+            .Build();
+        mockDatabaseOperation
+            .Setup(db => db.GetUsersWithLocalAuthoritiesAndConsortia())
+            .Returns(new List<User> { user });
+        mockDatabaseOperation
+            .Setup(db => db.GetConsortia(expectedConsortiumCodes))
+            .Returns(expectedConsortia);
+
+        return (user, localAuthorities, expectedConsortia);
+    }
+}


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1086)

# Description

adds a new management command `FixAllUserOwnedConsortia` which will fix all users that should be consortium admins.
the results of every operation is logged and confirmation is required before migrating any users for safety.

this is tested in FixAllUserOwnedConsortiaCommandTests, which is pulled out to a separate tests file as CommandHandlerTests is becoming large. if needed the file could be split into more classes, or a single test class over a set of files using partial classes

# Checklist

- [x] [I have made any necessary updates to the documentation](https://softwiretech.atlassian.net/wiki/spaces/Support/pages/20606746709/DESNZ+HUG2+Common+Tasks#6.-Migrating-Users-Script)
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it

# Screenshots

 ![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta/assets/108681823/6af1f2a5-7d96-4b6d-9729-6d0c6164ddbd)