### PR TITLE
PC-NONE: Add note about database migrations

### DIFF
--- a/HerPortal/Program.cs
+++ b/HerPortal/Program.cs
@@ -26,7 +26,12 @@ namespace HerPortal
 
             startup.Configure(app, app.Environment);
 
-            // Migrate the database if it's out of date
+            // Migrate the database if it's out of date. Ideally we wouldn't do this on app startup for our deployed
+            // environments, because we're risking multiple containers attempting to run the migrations concurrently and
+            // getting into a mess. However, we very rarely add migrations at this point, so in practice it's easier to
+            // risk it and keep an eye on the deployment: we should be doing rolling deployments anyway which makes it
+            // very unlikely we run into concurrency issues. If that changes though we should look at moving migrations
+            // to a deployment pipeline step, and only doing the following locally (PC-1151).
             using var scope = app.Services.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<HerDbContext>();
             dbContext.Database.Migrate();


### PR DESCRIPTION
# Description

Adds a note to explain why what we're doing isn't ideal, but why we're doing it regardless, and refer to Jira ticket.

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [ ] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [ ] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [ ] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the main HUG2 repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta)

# Screenshots

n/a