### PR TITLE
PC-NONE: add miro board to mr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@ Add the ticket number below and uncomment
 - [ ] I have checked there are no unintentional line ending changes
 - [ ] I have added tests where applicable
 - [ ] If I have made any changes to the code, I have used the IDE auto-formatter on it
+- [ ] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVK4g4M0Q=/)
 - [ ] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
 - [ ] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the main HUG2 repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta)
 


### PR DESCRIPTION
# Description

Adds a link to the [Miro Board for HUG2](https://miro.com/app/board/uXjVK4g4M0Q=/) to the PR checklist