### PR TITLE
PC-NONE: bump net version in compile js script

### DIFF
--- a/HerPortal/compile-sass-and-js.js
+++ b/HerPortal/compile-sass-and-js.js
@@ -7,7 +7,7 @@ var UglifyJS = require("uglify-js");
 
 
 var pathToCurrentDirectory = './';
-var pathToVisualStudioDebugDirectory = './bin/Debug/net6.0/';
+var pathToVisualStudioDebugDirectory = './bin/Debug/net8.0/';
 
 var inputDirectory = './wwwroot';
 var inputJsDirectory = './wwwroot/js';


### PR DESCRIPTION
# Description

now refers to build output from net8.0